### PR TITLE
update the pr metadata prompt

### DIFF
--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -31,6 +31,7 @@ export interface CodexStreamCallbacks {
 export class CodexAgent {
   private config: CodexConfig;
   private sbx?: Sandbox;
+  private lastPrompt?: string;
 
   constructor(config: CodexConfig) {
     this.config = config;
@@ -131,6 +132,8 @@ export class CodexAgent {
         }", "output": "${JSON.stringify(result)}"}`
       );
 
+      this.lastPrompt = prompt;
+
       return {
         sandboxId: sbx.sandboxId,
         ...result,
@@ -181,7 +184,8 @@ export class CodexAgent {
     const { title, body, branchName, commitMessage } = await generatePRMetadata(
       patch?.stdout || "",
       "codex",
-      this.config.openaiApiKey
+      this.config.openaiApiKey,
+      this.lastPrompt || ""
     );
 
     const checkout = await this.sbx?.commands.run(

--- a/src/agents/utils.ts
+++ b/src/agents/utils.ts
@@ -6,9 +6,10 @@ import { z } from "zod";
 export async function generatePRMetadata(
   patch: string,
   agent: "codex" | "claude",
-  apiKey: string
+  apiKey: string,
+  prompt: string
 ) {
-  const prompt = `You are tasked to create title and body for a pull request based on the following patch:\n\n${patch}`;
+  const _prompt = `You are tasked to create title and body for a pull request based on the following task:\n${prompt}\n\npatch:\n\n${patch}`;
   const model =
     agent === "codex" ? createOpenAI({ apiKey }) : createAnthropic({ apiKey });
 
@@ -17,7 +18,7 @@ export async function generatePRMetadata(
       agent === "codex"
         ? model("gpt-4o-mini")
         : model("claude-3-5-sonnet-20240620"),
-    prompt,
+    prompt: _prompt,
     schema: z.object({
       title: z.string().describe("Suggested title for the pull request"),
       body: z.string().describe("Suggested body for the pull request"),


### PR DESCRIPTION
This pull request introduces a mechanism to include the last prompt used by the `CodexAgent` in the metadata generation for pull requests. The changes span across the `CodexAgent` class and the `generatePRMetadata` function, ensuring that the context of the last prompt is preserved and utilized.

### Enhancements to `CodexAgent`:

* Added a new private property `lastPrompt` to the `CodexAgent` class to store the last prompt used. (`src/agents/codex.ts`, [src/agents/codex.tsR34](diffhunk://#diff-7bbd575ce3ff8bc960a43fa92879c8c8672be7da945fbbfb501007bfd383a652R34))
* Updated the `CodexAgent` to assign the current prompt to `lastPrompt` after generating a result. (`src/agents/codex.ts`, [src/agents/codex.tsR135-R136](diffhunk://#diff-7bbd575ce3ff8bc960a43fa92879c8c8672be7da945fbbfb501007bfd383a652R135-R136))
* Modified the call to `generatePRMetadata` in `CodexAgent` to pass the `lastPrompt` value, providing additional context for pull request metadata generation. (`src/agents/codex.ts`, [src/agents/codex.tsL184-R188](diffhunk://#diff-7bbd575ce3ff8bc960a43fa92879c8c8672be7da945fbbfb501007bfd383a652L184-R188))

### Updates to `generatePRMetadata`:

* Added a new `prompt` parameter to the `generatePRMetadata` function to accept the additional context. (`src/agents/utils.ts`, [src/agents/utils.tsL9-R12](diffhunk://#diff-decaf7b76131c0ce9f6c2867d8f69be6871b081feadae0d3234927089a0bcd46L9-R12))
* Adjusted the internal prompt construction in `generatePRMetadata` to include both the task description and the patch content, improving the clarity of the generated metadata. (`src/agents/utils.ts`, [src/agents/utils.tsL20-R21](diffhunk://#diff-decaf7b76131c0ce9f6c2867d8f69be6871b081feadae0d3234927089a0bcd46L20-R21))