### PR TITLE
add model config to claude agent

### DIFF
--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -8,6 +8,7 @@ import {
 
 export class ClaudeAgent extends BaseAgent {
   private anthropicApiKey: string;
+  private model?: string;
 
   constructor(config: ClaudeConfig) {
     const baseConfig: BaseAgentConfig = {
@@ -21,6 +22,7 @@ export class ClaudeAgent extends BaseAgent {
 
     super(baseConfig);
     this.anthropicApiKey = config.anthropicApiKey;
+    this.model = config.model;
   }
 
   protected getCommandConfig(
@@ -41,7 +43,9 @@ export class ClaudeAgent extends BaseAgent {
     return {
       command: `echo "${prompt}" | claude -p --append-system-prompt "${instruction}"${
         mode === "ask" ? ' --disallowedTools "Edit" "Replace" "Write"' : ""
-      } --output-format stream-json --verbose`,
+      } --output-format stream-json --verbose --model ${
+        this.model || "claude-sonnet-4-20250514"
+      }`,
       errorPrefix: "Claude",
       labelName: "claude",
       labelColor: "FF6B35",
@@ -97,7 +101,9 @@ export class ClaudeAgent extends BaseAgent {
       ...originalGetCommandConfig(p, m),
       command: `echo "${prompt}" | claude -p --append-system-prompt "${instruction}"${
         mode === "ask" ? ' --disallowedTools "Edit" "Replace" "Write"' : ""
-      } --output-format stream-json --verbose --dangerously-skip-permissions`,
+      } --output-format stream-json --verbose --dangerously-skip-permissions --model ${
+        this.model || "claude-sonnet-4-20250514"
+      }`,
     });
 
     const result = await super.generateCode(prompt, mode, history, callbacks);


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request enhances the `ClaudeAgent` class by introducing support for custom AI models and ensuring robust testing for this functionality. The most important changes include adding a `model` property to the agent, modifying command generation to include the model parameter, and extending the test suite to validate the behavior with custom and default models.

### Updates to `ClaudeAgent` functionality:

* Added a `model` property to the `ClaudeAgent` class, allowing users to specify a custom AI model via configuration. (`src/agents/claude.ts`, [[1]](diffhunk://#diff-e885cfe6c78e98bda100571a17bef48b0634bad1c95f6b54bdb6a0e1d3d24f38R11) [[2]](diffhunk://#diff-e885cfe6c78e98bda100571a17bef48b0634bad1c95f6b54bdb6a0e1d3d24f38R25)
* Updated command generation logic to include the `--model` parameter, defaulting to `"claude-sonnet-4-20250514"` if no model is specified. (`src/agents/claude.ts`, [[1]](diffhunk://#diff-e885cfe6c78e98bda100571a17bef48b0634bad1c95f6b54bdb6a0e1d3d24f38L44-R48) [[2]](diffhunk://#diff-e885cfe6c78e98bda100571a17bef48b0634bad1c95f6b54bdb6a0e1d3d24f38L100-R106)

### Enhancements to test coverage:

* Added tests to verify initialization with custom and default models. (`test/claude.test.ts`, [test/claude.test.tsR53-R65](diffhunk://#diff-1a6b245957aca61fe61215c90ab183bcc56b910fd78f90da7bd293cdd108c31dR53-R65))
* Extended tests to validate command generation with the correct model parameter, including scenarios with conversation history. (`test/claude.test.ts`, [[1]](diffhunk://#diff-1a6b245957aca61fe61215c90ab183bcc56b910fd78f90da7bd293cdd108c31dL175-R188) [[2]](diffhunk://#diff-1a6b245957aca61fe61215c90ab183bcc56b910fd78f90da7bd293cdd108c31dR279-R295)
* Ensured proper handling of default and custom models during `generateCode` execution. (`test/claude.test.ts`, [test/claude.test.tsL187-R231](diffhunk://#diff-1a6b245957aca61fe61215c90ab183bcc56b910fd78f90da7bd293cdd108c31dL187-R231))

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe)
