### PR TITLE
add support for using non-gpt models with codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ logs
 test-codex.ts
 test-pr.ts
 test-claude.ts
+test-codex-gemini.ts

--- a/src/agents/claude.ts
+++ b/src/agents/claude.ts
@@ -4,6 +4,7 @@ import {
   ClaudeResponse,
   ClaudeStreamCallbacks,
   Conversation,
+  ModelProvider,
 } from "../types";
 
 export class ClaudeAgent extends BaseAgent {
@@ -21,7 +22,13 @@ export class ClaudeAgent extends BaseAgent {
     };
 
     super(baseConfig);
-    this.anthropicApiKey = config.anthropicApiKey;
+
+    // Validate that provider is anthropic if specified (Claude only supports anthropic)
+    if (config.provider && config.provider !== "anthropic") {
+      throw new Error("Claude agent only supports 'anthropic' provider");
+    }
+
+    this.anthropicApiKey = config.providerApiKey;
     this.model = config.model;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
   AgentType,
   AgentMode,
   AgentModel,
+  ModelProvider,
   E2BConfig,
   DaytonaConfig,
   EnvironmentConfig,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,22 @@ export type AgentType = "codex" | "claude";
 
 export type AgentMode = "ask" | "code";
 
+export type ModelProvider =
+  | "openai"
+  | "anthropic"
+  | "openrouter"
+  | "azure"
+  | "gemini"
+  | "ollama"
+  | "mistral"
+  | "deepseek"
+  | "xai"
+  | "groq"
+  | "arceeai";
+
 export type AgentModel = {
   name?: string;
+  provider?: ModelProvider;
   apiKey: string;
 };
 
@@ -53,7 +67,6 @@ export type VibeKitConfig = {
   agent: {
     type: AgentType;
     model: AgentModel;
-    mode: AgentMode;
   };
   environment: EnvironmentConfig;
   github?: GithubConfig;
@@ -80,7 +93,8 @@ export interface ClaudeStreamCallbacks {
 
 // CODEX CONFIG
 export interface CodexConfig {
-  openaiApiKey: string;
+  providerApiKey?: string;
+  provider?: ModelProvider;
   githubToken?: string;
   repoUrl?: string; // org/repo, e.g. "octocat/hello-world"
   e2bApiKey: string;
@@ -103,7 +117,8 @@ export interface CodexResponse {
 
 // CLAUDE CONFIG
 export interface ClaudeConfig {
-  anthropicApiKey: string;
+  providerApiKey: string;
+  provider?: ModelProvider;
   githubToken?: string;
   repoUrl?: string; // org/repo, e.g. "octocat/hello-world"
   e2bApiKey: string;

--- a/test/claude.test.ts
+++ b/test/claude.test.ts
@@ -16,7 +16,7 @@ describe("ClaudeAgent", () => {
 
   beforeEach(() => {
     config = {
-      anthropicApiKey: "test-anthropic-key",
+      providerApiKey: "test-anthropic-key",
       githubToken: "test-github-token",
       repoUrl: "octocat/hello-world",
       e2bApiKey: "test-e2b-key",
@@ -62,6 +62,30 @@ describe("ClaudeAgent", () => {
       delete configWithoutModel.model;
       const agentWithoutModel = new ClaudeAgent(configWithoutModel);
       expect(agentWithoutModel).toBeInstanceOf(ClaudeAgent);
+    });
+
+    it("should accept anthropic provider", () => {
+      const configWithAnthropicProvider = {
+        ...config,
+        provider: "anthropic" as const,
+      };
+      const agent = new ClaudeAgent(configWithAnthropicProvider);
+      expect(agent).toBeInstanceOf(ClaudeAgent);
+    });
+
+    it("should reject non-anthropic providers", () => {
+      const configWithOpenAiProvider = {
+        ...config,
+        provider: "openai" as const,
+      };
+      expect(() => new ClaudeAgent(configWithOpenAiProvider)).toThrow(
+        "Claude agent only supports 'anthropic' provider"
+      );
+    });
+
+    it("should work without provider specified (defaults to anthropic)", () => {
+      const agent = new ClaudeAgent(config);
+      expect(agent).toBeInstanceOf(ClaudeAgent);
     });
   });
 

--- a/test/vibekit.test.ts
+++ b/test/vibekit.test.ts
@@ -24,7 +24,6 @@ describe("VibeKit", () => {
           name: "gpt-4",
           apiKey: "test-openai-key",
         },
-        mode: "code",
       },
       environment: {
         e2b: {
@@ -44,7 +43,6 @@ describe("VibeKit", () => {
           name: "claude-3-5-sonnet-20241022",
           apiKey: "test-anthropic-key",
         },
-        mode: "code",
       },
       environment: {
         e2b: {
@@ -87,7 +85,6 @@ describe("VibeKit", () => {
             name: "gpt-4",
             apiKey: "test-openai-key",
           },
-          mode: "code",
         },
         environment: {
           daytona: {
@@ -124,7 +121,7 @@ describe("VibeKit", () => {
 
       expect(MockedCodexAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          openaiApiKey: "test-openai-key",
+          providerApiKey: "test-openai-key",
           githubToken: "test-github-token",
           repoUrl: "octocat/hello-world",
           e2bApiKey: "test-e2b-key",
@@ -147,7 +144,6 @@ describe("VibeKit", () => {
             name: "gpt-4",
             apiKey: "test-openai-key",
           },
-          mode: "code",
         },
         environment: {
           e2b: {
@@ -170,7 +166,7 @@ describe("VibeKit", () => {
 
       expect(MockedCodexAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          openaiApiKey: "test-openai-key",
+          providerApiKey: "test-openai-key",
           githubToken: undefined,
           repoUrl: undefined,
           e2bApiKey: "test-e2b-key",
@@ -200,7 +196,7 @@ describe("VibeKit", () => {
 
       expect(MockedClaudeAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          anthropicApiKey: "test-anthropic-key",
+          providerApiKey: "test-anthropic-key",
           githubToken: "test-github-token",
           repoUrl: "octocat/hello-world",
           e2bApiKey: "test-e2b-key",
@@ -222,7 +218,6 @@ describe("VibeKit", () => {
             name: "claude-3-5-sonnet-20241022",
             apiKey: "test-anthropic-key",
           },
-          mode: "code",
         },
         environment: {
           e2b: {
@@ -246,7 +241,7 @@ describe("VibeKit", () => {
 
       expect(MockedClaudeAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          anthropicApiKey: "test-anthropic-key",
+          providerApiKey: "test-anthropic-key",
           githubToken: undefined,
           repoUrl: undefined,
           e2bApiKey: "test-e2b-key",
@@ -317,7 +312,6 @@ describe("VibeKit", () => {
           model: {
             apiKey: "test-key",
           },
-          mode: "code" as any,
         },
         environment: {
           e2b: {
@@ -352,7 +346,7 @@ describe("VibeKit", () => {
 
       expect(MockedCodexAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          openaiApiKey: "test-openai-key",
+          providerApiKey: "test-openai-key",
           githubToken: "test-github-token",
           repoUrl: "octocat/hello-world",
           e2bApiKey: "test-e2b-key",
@@ -378,7 +372,7 @@ describe("VibeKit", () => {
 
       expect(MockedClaudeAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          anthropicApiKey: "test-anthropic-key",
+          providerApiKey: "test-anthropic-key",
           githubToken: "test-github-token",
           repoUrl: "octocat/hello-world",
           e2bApiKey: "test-e2b-key",
@@ -396,7 +390,6 @@ describe("VibeKit", () => {
             name: "gpt-4",
             apiKey: "test-openai-key",
           },
-          mode: "code",
         },
         environment: {
           e2b: {
@@ -427,7 +420,6 @@ describe("VibeKit", () => {
             name: "claude-3-5-sonnet-20241022",
             apiKey: "test-anthropic-key",
           },
-          mode: "code",
         },
         environment: {
           e2b: {
@@ -461,7 +453,7 @@ describe("VibeKit", () => {
 
         expect(MockedCodexAgent).toHaveBeenCalledWith(
           expect.objectContaining({
-            openaiApiKey: "test-openai-key",
+            providerApiKey: "test-openai-key",
             githubToken: "test-github-token",
             repoUrl: "octocat/hello-world",
             e2bApiKey: "test-e2b-key",
@@ -478,7 +470,7 @@ describe("VibeKit", () => {
 
         expect(MockedClaudeAgent).toHaveBeenCalledWith(
           expect.objectContaining({
-            anthropicApiKey: "test-anthropic-key",
+            providerApiKey: "test-anthropic-key",
             githubToken: "test-github-token",
             repoUrl: "octocat/hello-world",
             e2bApiKey: "test-e2b-key",
@@ -496,7 +488,7 @@ describe("VibeKit", () => {
 
         expect(MockedCodexAgent).toHaveBeenCalledWith(
           expect.objectContaining({
-            openaiApiKey: "test-openai-key",
+            providerApiKey: "test-openai-key",
             githubToken: "test-github-token",
             repoUrl: "octocat/hello-world",
             e2bApiKey: "test-e2b-key",
@@ -513,7 +505,7 @@ describe("VibeKit", () => {
 
         expect(MockedClaudeAgent).toHaveBeenCalledWith(
           expect.objectContaining({
-            anthropicApiKey: "test-anthropic-key",
+            providerApiKey: "test-anthropic-key",
             githubToken: "test-github-token",
             repoUrl: "octocat/hello-world",
             e2bApiKey: "test-e2b-key",
@@ -531,7 +523,7 @@ describe("VibeKit", () => {
 
         expect(MockedCodexAgent).toHaveBeenCalledWith(
           expect.objectContaining({
-            openaiApiKey: "test-openai-key",
+            providerApiKey: "test-openai-key",
             githubToken: "test-github-token",
             repoUrl: "octocat/hello-world",
             e2bApiKey: "test-e2b-key",
@@ -548,7 +540,7 @@ describe("VibeKit", () => {
 
         expect(MockedClaudeAgent).toHaveBeenCalledWith(
           expect.objectContaining({
-            anthropicApiKey: "test-anthropic-key",
+            providerApiKey: "test-anthropic-key",
             githubToken: "test-github-token",
             repoUrl: "octocat/hello-world",
             e2bApiKey: "test-e2b-key",


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request introduces significant updates to the agent configuration system, enabling support for multiple model providers and improving backward compatibility. It also refines the telemetry tracking logic and updates tests to validate the new functionality.

### Updates to agent configuration:

* [`src/types.ts`](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR6-R21): Added a new `ModelProvider` type to support multiple providers (e.g., "openai", "anthropic"). Updated `AgentModel` and configuration interfaces (`CodexConfig`, `ClaudeConfig`) to include the `provider` field. Removed the `AgentMode` field from `VibeKitConfig`. [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR6-R21) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL56) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL83-R97) [[4]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aL106-R121)

* `src/agents/claude.ts` and `src/agents/codex.ts`: Refactored agent constructors to validate and initialize the `provider` field. Added support for backward compatibility with deprecated API key fields. Updated command generation logic to include `--provider` and environment variable setup for custom providers. [[1]](diffhunk://#diff-e885cfe6c78e98bda100571a17bef48b0634bad1c95f6b54bdb6a0e1d3d24f38L24-R31) [[2]](diffhunk://#diff-7bbd575ce3ff8bc960a43fa92879c8c8672be7da945fbbfb501007bfd383a652L24-R36) [[3]](diffhunk://#diff-7bbd575ce3ff8bc960a43fa92879c8c8672be7da945fbbfb501007bfd383a652L47-R60) [[4]](diffhunk://#diff-7bbd575ce3ff8bc960a43fa92879c8c8672be7da945fbbfb501007bfd383a652R74-R81)

### Updates to telemetry tracking:

* [`src/core/vibekit.ts`](diffhunk://#diff-205aceb2c28cf5ce9e906d6f08698a805a7f04fbf8d629f00bbb51018f4517d7L98-R107): Simplified telemetry tracking by removing the `agentMode` fallback logic and directly using the `mode` parameter. Updated all telemetry-related calls to reflect this change. [[1]](diffhunk://#diff-205aceb2c28cf5ce9e906d6f08698a805a7f04fbf8d629f00bbb51018f4517d7L98-R107) [[2]](diffhunk://#diff-205aceb2c28cf5ce9e906d6f08698a805a7f04fbf8d629f00bbb51018f4517d7L119-R120) [[3]](diffhunk://#diff-205aceb2c28cf5ce9e906d6f08698a805a7f04fbf8d629f00bbb51018f4517d7L133-R134) [[4]](diffhunk://#diff-205aceb2c28cf5ce9e906d6f08698a805a7f04fbf8d629f00bbb51018f4517d7L146-R154)

### Test enhancements:

* `test/claude.test.ts` and `test/codex.test.ts`: Added tests to validate provider-specific behavior, including error handling for unsupported providers and environment variable setup for custom providers. Updated existing tests to use the new `providerApiKey` field. [[1]](diffhunk://#diff-1a6b245957aca61fe61215c90ab183bcc56b910fd78f90da7bd293cdd108c31dR66-R89) [[2]](diffhunk://#diff-0b5fbc1f52c03eb4bce0f737021b002d2b57c0dd2599f1672fcf6ecb46aca31eR55-R81) [[3]](diffhunk://#diff-0b5fbc1f52c03eb4bce0f737021b002d2b57c0dd2599f1672fcf6ecb46aca31eL176-R203) [[4]](diffhunk://#diff-0b5fbc1f52c03eb4bce0f737021b002d2b57c0dd2599f1672fcf6ecb46aca31eL191-R269)

* [`test/vibekit.test.ts`](diffhunk://#diff-1d390f04cc74502d4a4dd54174a5befbe075d9f1ea45c89bb2c65cab855c9e4bL27): Removed references to `AgentMode` in test configurations to align with the updated `VibeKitConfig`. [[1]](diffhunk://#diff-1d390f04cc74502d4a4dd54174a5befbe075d9f1ea45c89bb2c65cab855c9e4bL27) [[2]](diffhunk://#diff-1d390f04cc74502d4a4dd54174a5befbe075d9f1ea45c89bb2c65cab855c9e4bL47) [[3]](diffhunk://#diff-1d390f04cc74502d4a4dd54174a5befbe075d9f1ea45c89bb2c65cab855c9e4bL90)

## Related Issue
Fixes #21 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe)
