### PR TITLE
Fix/markdown code syntax in prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
-    "version": "0.0.21",
+    "version": "0.0.22",
     "exports": {
         ".": {
             "import": "./dist/index.js",

--- a/src/agents/codex.ts
+++ b/src/agents/codex.ts
@@ -12,6 +12,11 @@ export class CodexAgent extends BaseAgent {
   private provider: ModelProvider;
   private model?: string;
 
+  private escapePrompt(prompt: string): string {
+    // Escape backticks and other special characters
+    return prompt.replace(/[`"$\\]/g, "\\$&");
+  }
+
   constructor(config: CodexConfig) {
     if (!config.sandboxConfig) {
       throw new Error("sandboxConfig is required");
@@ -54,7 +59,8 @@ export class CodexAgent extends BaseAgent {
         "Don't ask any follow up questions.";
     }
 
-    let _prompt = `${instruction}\n\nUser: ${prompt}`;
+    const escapedPrompt = this.escapePrompt(prompt);
+    let _prompt = `${instruction}\n\nUser: ${escapedPrompt}`;
 
     return {
       command: `codex --approval-mode auto-edit${
@@ -108,7 +114,8 @@ export class CodexAgent extends BaseAgent {
         "Don't ask any follow up questions.";
     }
 
-    let _prompt = `${instruction}\n\nUser: ${prompt}`;
+    const escapedPrompt = this.escapePrompt(prompt);
+    let _prompt = `${instruction}\n\nUser: ${escapedPrompt}`;
 
     if (history) {
       _prompt += `\n\nConversation history: ${history


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->

This pull request introduces improvements to input sanitization for both the `ClaudeAgent` and `CodexAgent` classes, ensuring that user prompts are properly escaped to prevent issues with special characters. Additionally, it includes a minor version bump in the `package.json` file.

### Input Sanitization Improvements:

* **`ClaudeAgent` class (`src/agents/claude.ts`)**:
  - Added a new `escapePrompt` method to sanitize user prompts by escaping special characters such as backticks, double quotes, dollar signs, and backslashes.
  - Updated the `command` string in the `getCommandConfig` method to use the sanitized `escapedPrompt` instead of the raw `prompt`. [[1]](diffhunk://#diff-e885cfe6c78e98bda100571a17bef48b0634bad1c95f6b54bdb6a0e1d3d24f38R58-R61) [[2]](diffhunk://#diff-e885cfe6c78e98bda100571a17bef48b0634bad1c95f6b54bdb6a0e1d3d24f38R116-R122)

* **`CodexAgent` class (`src/agents/codex.ts`)**:
  - Introduced a similar `escapePrompt` method for prompt sanitization.
  - Modified the `_prompt` construction logic to include the sanitized `escapedPrompt` in place of the raw `prompt`. [[1]](diffhunk://#diff-7bbd575ce3ff8bc960a43fa92879c8c8672be7da945fbbfb501007bfd383a652L57-R63) [[2]](diffhunk://#diff-7bbd575ce3ff8bc960a43fa92879c8c8672be7da945fbbfb501007bfd383a652L111-R118)

### Miscellaneous:

* **Version update in `package.json`**:
  - Incremented the package version from `0.0.21` to `0.0.22` to reflect the changes made in this pull request.

