### PR TITLE
MCP support using flexible tooling

### DIFF
--- a/src/services/sandbox.ts
+++ b/src/services/sandbox.ts
@@ -14,6 +14,7 @@ import {
   ApiClientInMemoryContextProvider,
   GetServicePortsResult,
 } from "@northflank/js-client";
+import { toolingManager } from "./tooling";
 
 // E2B implementation
 export class E2BSandboxInstance implements SandboxInstance {
@@ -73,6 +74,8 @@ export class E2BSandboxProvider implements SandboxProvider {
     envs?: Record<string, string>,
     agentType?: AgentType
   ): Promise<SandboxInstance> {
+    // Inject tools before sandbox creation
+    await toolingManager.injectTools(config);
     // Determine default template based on agent type if not specified in config
     let templateId = config.templateId;
     if (!templateId) {
@@ -219,6 +222,8 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     envs?: Record<string, string>,
     agentType?: AgentType
   ): Promise<SandboxInstance> {
+    // Inject tools before sandbox creation
+    await toolingManager.injectTools(config);
     try {
       // Dynamic import to avoid dependency issues if daytona-sdk is not installed
       const daytonaConfig: DaytonaConfig = {
@@ -523,6 +528,8 @@ export class NorthflankSandboxProvider implements SandboxProvider {
     envs?: Record<string, string>,
     agentType?: AgentType
   ): Promise<SandboxInstance> {
+    // Inject tools before sandbox creation
+    await toolingManager.injectTools(config);
     if (!config.projectId || !config.apiKey) {
       throw new Error(
         "Northflank sandbox configuration missing one of required parameters: projectId, apiKey"

--- a/src/services/tooling.ts
+++ b/src/services/tooling.ts
@@ -1,0 +1,58 @@
+// Tool interface definition
+export interface Tool {
+  name: string;
+  injectToSandbox?: (sandboxConfig: any) => void | Promise<void>;
+  // Additional properties/methods as needed
+}
+
+// ToolingManager for registering and retrieving tools
+type ToolRegistry = Record<string, Tool>;
+
+export class ToolingManager {
+  private tools: ToolRegistry = {};
+
+  registerTool(tool: Tool) {
+    this.tools[tool.name] = tool;
+  }
+
+  unregisterTool(name: string) {
+    delete this.tools[name];
+  }
+
+  getTool(name: string): Tool | undefined {
+    return this.tools[name];
+  }
+
+  // Get all tools for a given sandbox config (e.g., by config.tools or other logic)
+  getToolsForSandbox(config: { tools?: string[] }): Tool[] {
+    if (!config.tools) return [];
+    return config.tools.map((name) => this.tools[name]).filter(Boolean) as Tool[];
+  }
+
+  // Inject all tools for a sandbox config (calls injectToSandbox if present)
+  async injectTools(config: { tools?: string[] }) {
+    const tools = this.getToolsForSandbox(config);
+    for (const tool of tools) {
+      if (tool.injectToSandbox) {
+        await tool.injectToSandbox(config);
+      }
+    }
+  }
+}
+
+// Singleton instance
+export const toolingManager = new ToolingManager();
+
+// Example MCP tool
+export const mcpTool: Tool = {
+  name: "mcp",
+  injectToSandbox: async (sandboxConfig) => {
+    // Placeholder: In a real implementation, modify envs, mount files, etc.
+    if (!sandboxConfig.envs) sandboxConfig.envs = {};
+    sandboxConfig.envs.MCP_ENABLED = "1";
+    // You could also mount binaries, scripts, etc. here
+    console.log("MCP tool injected into sandbox config");
+  },
+};
+
+toolingManager.registerTool(mcpTool); 

--- a/src/types.ts
+++ b/src/types.ts
@@ -275,6 +275,7 @@ export interface SandboxConfig {
   persistentVolume?: string; // for Northflank
   persistentVolumeStorage?: number; // for Northflank
   workingDirectory?: string; // for Nortflank
+  tools?: string[]; // List of tool names to inject (e.g., ["mcp"])
 }
 
 export interface SandboxProvider {


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->

A new ToolingManager manages tool registration and injection.
SandboxConfig supports a tools array (e.g., tools: ["mcp"]).
All sandbox providers now call the tooling manager to inject tools before sandbox creation.
A sample MCP tool is registered, which demonstrates how to inject environment variables or perform other setup.

## Related Issue
Fixes #<issue number>
#66 

