### PR TITLE
fix: set one hour timeout on e2b

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
-    "version": "0.0.39",
+    "version": "0.0.40",
     "exports": {
         ".": {
             "import": "./dist/index.js",

--- a/src/services/sandbox.ts
+++ b/src/services/sandbox.ts
@@ -90,7 +90,7 @@ export class E2BSandboxProvider implements SandboxProvider {
     const sandbox = await E2BSandbox.create(templateId, {
       envs,
       apiKey: config.apiKey,
-      timeoutMs: 86400000, // 24 hours in milliseconds
+      timeoutMs: 3600000, // 1 hour in milliseconds
     });
     return new E2BSandboxInstance(sandbox);
   }


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request includes two changes: an update to the package version in `package.json` and a modification to the sandbox timeout duration in `src/services/sandbox.ts`.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L6-R6): Updated the package version from `0.0.39` to `0.0.40`.

Sandbox timeout adjustment:

* [`src/services/sandbox.ts`](diffhunk://#diff-39a6d4c0710b5c21adede7a11257804b86dcbe39cec69ee625e19ba3267d861fL93-R93): Reduced the sandbox timeout duration from 24 hours (86400000 milliseconds) to 1 hour (3600000 milliseconds) in the `E2BSandboxProvider` class.

## Related Issue
Fixes #98 

