### PR TITLE
fix issue with daytona not opening browser for authentication in the cli

### DIFF
--- a/packages/vibekit/src/cli/utils/auth.ts
+++ b/packages/vibekit/src/cli/utils/auth.ts
@@ -53,6 +53,7 @@ const authConfigs: Record<SANDBOX_PROVIDERS, ProviderAuthConfig> = {
       return { isAuthenticated: !isAuthError, username };
     },
     loginCommand: ['login'],
+    needsBrowserOpen: true,
   },
   [SANDBOX_PROVIDERS.NORTHFLANK]: {
     cliName: 'northflank',
@@ -192,6 +193,18 @@ export async function authenticate(provider: SANDBOX_PROVIDERS): Promise<boolean
 
     // Run login
     spinner.text = `Running ${provider} login...`;
+    
+    // Open browser for providers that need it
+    if (config.needsBrowserOpen) {
+      spinner.text = `Opening browser for ${provider} authentication...`;
+      // Wait a moment for the CLI to start before opening browser
+      setTimeout(() => {
+        open('https://auth.daytona.io').catch(() => {
+          // Silently fail if browser can't open
+        });
+      }, 1000);
+    }
+    
     await execa(config.cliName, config.loginCommand, { stdio: 'inherit' });
     
     // Verify with retries


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request introduces a feature to handle browser-based authentication for certain providers in the CLI tool. The key changes include adding a configuration flag to indicate if a provider requires a browser to be opened and implementing logic to handle this during the authentication process.

### Enhancements to authentication flow:

* [`packages/vibekit/src/cli/utils/auth.ts`](diffhunk://#diff-d4cbc4f506c784c28226a255ccc77f089e1ba604c646e4fc082f14ca737300ebR56): Added a new property, `needsBrowserOpen`, to the `ProviderAuthConfig` object to specify if a provider requires browser-based authentication.
* [`packages/vibekit/src/cli/utils/auth.ts`](diffhunk://#diff-d4cbc4f506c784c28226a255ccc77f089e1ba604c646e4fc082f14ca737300ebR196-R207): Updated the `authenticate` function to check the `needsBrowserOpen` flag. If true, it opens a browser to a specified authentication URL (`https://auth.daytona.io`) before proceeding with the CLI login process. A delay and error handling were added to ensure smooth operation.

## Related Issue
Fixes #118 

