### PR TITLE
feat: add GEMINI_API_KEY support for flexible Gemini agent configuration

### DIFF
--- a/packages/vibekit/src/cli/utils/config.ts
+++ b/packages/vibekit/src/cli/utils/config.ts
@@ -186,10 +186,12 @@ export function loadConfig(): CLIConfig {
   }
 
   const googleKey = getEnv("GOOGLE_API_KEY");
-  if (googleKey) {
+  const geminiKey = getEnv("GEMINI_API_KEY");
+  if (googleKey || geminiKey) {
     config.agents.google = {
-      apiKey: googleKey,
-      model: getEnv("GOOGLE_MODEL") || getEnv("VIBEKIT_DEFAULT_MODEL"),
+      apiKey: googleKey || geminiKey || "",
+      model: getEnv("GOOGLE_MODEL") || getEnv("GEMINI_MODEL") ||
+  getEnv("VIBEKIT_DEFAULT_MODEL"),
     };
   }
 


### PR DESCRIPTION
  ### Summary

  Adds support for GEMINI_API_KEY environment variable as an alternative
  to GOOGLE_API_KEY for configuring the Gemini agent, providing users
  with more flexible authentication options.

  ### Changes

  - Enhanced Gemini agent configuration to accept either GOOGLE_API_KEY
  or GEMINI_API_KEY
  - Added model variable support for both GOOGLE_MODEL and GEMINI_MODEL
  environment variables
  - Improved user experience by supporting common naming conventions used
   across different Gemini/Google AI tools

 ### Benefits

  - 🔄 Backward Compatible: Existing GOOGLE_API_KEY configurations
  continue to work unchanged
  - 🎯 User Friendly: Users can choose the environment variable name that
   fits their workflow
  - 🔗 Tool Compatibility: Supports naming conventions from various
  Gemini/Google AI tools
  - 📊 Model Flexibility: Supports both GOOGLE_MODEL and GEMINI_MODEL for
   model selection

 ### Usage Examples

  #### Option 1: Using Google naming (existing)
  export GOOGLE_API_KEY="your_google_api_key"
  export GOOGLE_MODEL="gemini-1.5-pro"

  #### Option 2: Using Gemini naming (new)
  export GEMINI_API_KEY="your_gemini_api_key"
  export GEMINI_MODEL="gemini-1.5-pro"