### PR TITLE
fix: clarify sandbox provider requirements in init command

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -126,8 +126,9 @@ export async function initCommand(
     console.log(chalk.yellow("📋 Requirements:"));
     console.log(chalk.gray("  • Internet connection"));
     console.log(chalk.gray("  • Docker installed and running"));
-    console.log(chalk.gray("  • Account on at least one sandbox provider"));
-    console.log(chalk.gray("    (Not required if using Dagger with Docker Hub)\n"));
+    console.log(chalk.gray("  • EITHER:"));
+    console.log(chalk.gray("    - Account on a cloud sandbox provider"));
+    console.log(chalk.gray("    - Dagger (for local sandboxes via Docker Hub)\n"));
 
     // Parse CLI options
     let providers: SANDBOX_PROVIDERS[] = [];

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -126,7 +126,8 @@ export async function initCommand(
     console.log(chalk.yellow("📋 Requirements:"));
     console.log(chalk.gray("  • Internet connection"));
     console.log(chalk.gray("  • Docker installed and running"));
-    console.log(chalk.gray("  • Account on at least one sandbox provider\n"));
+    console.log(chalk.gray("  • Account on at least one sandbox provider"));
+    console.log(chalk.gray("    (Not required if using Dagger with Docker Hub)\n"));
 
     // Parse CLI options
     let providers: SANDBOX_PROVIDERS[] = [];


### PR DESCRIPTION
## Summary
- Updated the requirements section in the `vibekit init` command to clarify that users don't need a cloud sandbox provider account if they're using Dagger with Docker Hub

## Changes
- Modified the requirements display to use an "EITHER:" format that clearly presents both options

## Before
```
📋 Requirements:
  • Internet connection
  • Docker installed and running
  • Account on at least one sandbox provider
```

## After
```
📋 Requirements:
  • Internet connection
  • Docker installed and running
  • EITHER:
    - Account on a cloud sandbox provider
    - Dagger (for local sandboxes via Docker Hub)
```

This change makes it immediately clear to users that they have two deployment options and don't need a cloud provider account if they choose to run sandboxes locally with Dagger.