### PR TITLE
Fix dashboard command path resolution and add port flag

### DIFF
--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -409,7 +409,8 @@ proxyCommand
 // Dashboard commands
 const dashboardCommand = program
   .command('dashboard')
-  .description('Manage analytics dashboard');
+  .description('Manage analytics dashboard')
+  .option('-p, --port <number>', 'Port to run dashboard on', '3001');
 
 dashboardCommand
   .command('start')
@@ -438,7 +439,7 @@ dashboardCommand
   .action(async (options, command) => {
     // If no subcommand was provided, start the dashboard with default settings
     if (command.args.length === 0) {
-      const port = 3001; // Default port when no subcommand is used
+      const port = parseInt(options.port) || 3001; // Use port option or default
       const { default: dashboardManager } = await import('./dashboard/manager.js');
       const dashboardServer = dashboardManager.getDashboardServer(port);
       

--- a/packages/cli/src/dashboard/server.ts
+++ b/packages/cli/src/dashboard/server.ts
@@ -29,7 +29,7 @@ class DashboardServer {
       console.log(chalk.blue(`🚀 Starting analytics dashboard on port ${this.port}...`));
 
       // Dashboard directory path - use the source directory
-      const dashboardDir = join(process.cwd(), 'src', 'dashboard');
+      const dashboardDir = join(process.cwd(), 'packages', 'cli', 'src', 'dashboard');
 
       // Start dashboard using npm run dev
       this.process = spawn('npm', ['run', 'dev', '--', '--port', this.port.toString()], {


### PR DESCRIPTION
## Summary

- Fixed dashboard startup failure due to incorrect directory path resolution
- Added port flag (`-p, --port`) to main dashboard command for better usability

## Changes

### Dashboard Path Fix
- **Issue**: `vibekit dashboard` was failing with "npm not found" error because it was looking for the dashboard in `src/dashboard` instead of `packages/cli/src/dashboard`
- **Fix**: Updated path resolution in `packages/cli/src/dashboard/server.ts` to use the correct full path

### Port Flag Addition
- **Issue**: Port flag was only available on `vibekit dashboard start -p <port>` subcommand, not on the main `vibekit dashboard -p <port>` command
- **Fix**: Added `-p, --port <number>` option to the main dashboard command and updated the default action to use the port parameter

## Test Plan

- [x] `vibekit dashboard` starts successfully on default port 3001
- [x] `vibekit dashboard -p 8080` starts successfully on custom port 8080  
- [x] `vibekit dashboard --port 8080` starts successfully on custom port 8080
- [x] `vibekit dashboard --help` shows the new port option
- [x] Dashboard loads correctly in browser at specified port