### PR TITLE
expose types in sdk

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-kit/sdk",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,14 +4,42 @@ export { VibeKit } from "./core/vibekit";
 // Constants exports
 export * from "./constants";
 
-// Essential type exports only
+// Type exports for user consumption
 export type {
   AgentType,
   AgentMode,
   ModelProvider,
-  SandboxProvider,
-  SandboxInstance,
+  AgentModel,
+  E2BConfig,
+  DaytonaConfig,
+  NorthflankConfig,
+  EnvironmentConfig,
+  GithubConfig,
+  SecretsConfig,
+  VibeKitConfig,
   Conversation,
+  LabelOptions,
+  CodexStreamCallbacks,
+  ClaudeStreamCallbacks,
+  OpenCodeStreamCallbacks,
+  GeminiStreamCallbacks,
+  GrokStreamCallbacks,
+  CodexConfig,
+  CodexResponse,
+  ClaudeConfig,
+  ClaudeResponse,
+  OpenCodeConfig,
+  OpenCodeResponse,
+  GeminiConfig,
+  GeminiResponse,
+  GrokConfig,
+  GrokResponse,
+  SandboxExecutionResult,
+  SandboxCommandOptions,
+  SandboxCommands,
+  SandboxInstance,
+  SandboxConfig,
+  SandboxProvider,
 } from "./types";
 
 // Optional exports with dynamic imports
@@ -43,9 +71,11 @@ export const createGrokAgent = async () => {
 // Authentication is handled separately via @vibe-kit/auth package
 // Users should get tokens from auth package and pass them as API keys
 
-// Type-only exports for advanced usage
-export type { ClaudeConfig, ClaudeResponse } from "./types";
-export type { CodexConfig, CodexResponse } from "./types";
-export type { OpenCodeConfig, OpenCodeResponse } from "./types";
-export type { GeminiConfig } from "./types";
-export type { BaseAgentConfig, PullRequestResult } from "./agents/base";
+// Additional type exports from agent base
+export type { 
+  BaseAgentConfig, 
+  PullRequestResult,
+  AgentResponse,
+  ExecuteCommandOptions,
+  StreamCallbacks
+} from "./agents/base";

--- a/test/vibekit.test.ts
+++ b/test/vibekit.test.ts
@@ -5,9 +5,38 @@ import { VibeKit } from "../packages/sdk/src/index.js";
 import { createE2BProvider } from "../packages/e2b/dist/index.js";
 import { skipIfNoVibeKitKeys, skipTest } from "./helpers/test-utils.js";
 
+// Type imports to verify they are properly exported
+import type {
+  AgentMode,
+  ModelProvider,
+  Conversation,
+  PullRequestResult,
+  AgentResponse,
+  ExecuteCommandOptions,
+} from "../packages/sdk/src/index.js";
+
 dotenv.config();
 
 describe("VibeKit SDK", () => {
+  it("should have all types properly exported", () => {
+    // Type checking test - these will fail at compile time if types are not exported
+    // We're just verifying the types can be used, not testing runtime behavior
+    type TestAgentMode = AgentMode;
+    type TestProvider = ModelProvider;
+    type TestConversation = Conversation;
+    type TestAgentResponse = AgentResponse;
+    type TestExecuteOptions = ExecuteCommandOptions;
+    type TestPrResult = PullRequestResult;
+    
+    // Example usage to verify types work correctly
+    const agentMode: TestAgentMode = "code";
+    const provider: TestProvider = "anthropic";
+    
+    // If this test compiles and runs, all types are properly exported
+    expect(agentMode).toBe("code");
+    expect(provider).toBe("anthropic");
+  });
+
   it("should create working directory", async () => {
     if (skipIfNoVibeKitKeys()) {
       return skipTest();


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->

This pull request improves the type export surface of the `@vibe-kit/sdk` package, making it easier for users to access and use essential and advanced TypeScript types directly from the SDK entry point. It also adds a test to ensure these types are properly exported and available for consumption.

**Type export enhancements:**

* Expanded the set of exported types in `packages/sdk/src/index.ts` to include additional configuration, response, and callback types for agents, sandboxes, and providers, making them available for user consumption.
* Added exports for advanced types such as `AgentResponse`, `ExecuteCommandOptions`, and `StreamCallbacks` from `./agents/base` for advanced usage scenarios.

**Testing improvements:**

* Introduced a type-checking test in `test/vibekit.test.ts` to verify that all relevant types are properly exported and can be used in downstream projects. This ensures type exports remain stable and accessible.

**Package version update:**

* Bumped the SDK version from `0.0.59` to `0.0.60` in `packages/sdk/package.json` to reflect these changes.

## Related Issue
Fixes #168 

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code