### PR TITLE
fix issue with docker initialization

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,12 +1,16 @@
 {
   "name": "vibekit",
-  "version": "0.0.1-rc.23",
+  "version": "0.0.1-rc.26",
   "description": "Run Claude Code, Gemini, Codex — or any coding agent — in a clean, isolated sandbox with sensitive data redaction and observability baked in.",
   "main": "dist/cli.js",
   "type": "module",
   "bin": {
     "vibekit": "./dist/cli.js"
   },
+  "files": [
+    "dist/**/*",
+    "Dockerfile"
+  ],
   "scripts": {
     "build": "tsup",
     "dev": "tsup src/cli.js --watch",

--- a/packages/cli/src/sandbox/sandbox-config.js
+++ b/packages/cli/src/sandbox/sandbox-config.js
@@ -55,7 +55,6 @@ export class SandboxConfig {
         // If user specified docker but only podman available (or vice versa), auto-switch
         if (source !== 'cli') {
           sandboxType = availableRuntime;
-          SandboxUtils.logSandboxOperation(`Auto-detected container runtime: ${availableRuntime}`);
         }
       }
     }


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request updates the CLI package version and significantly improves the Docker sandbox's robustness in locating the `Dockerfile` across various installation and execution scenarios. It also removes some log messages to reduce unnecessary output.

**Improvements to Dockerfile discovery and sandbox initialization:**

* Enhanced the logic in `docker-sandbox.js` to search for the `Dockerfile` in multiple locations, including the current directory, workspace root, compiled package directories, and `node_modules`, ensuring the Docker sandbox can be built regardless of how or where the CLI is installed or run. If the file is not found, the error message now lists all searched paths for easier debugging.
* Removed the log message when building the sandbox image if it does not exist, resulting in a cleaner output.

**Logging and environment variable handling:**

* Removed the warning log about a missing `ANTHROPIC_API_KEY` environment variable when running the container, reducing noise for users who do not require this key.
* Suppressed the log message that announced auto-detection of the container runtime, further streamlining CLI output.

**Package configuration:**

* Updated the CLI package version to `0.0.1-rc.26` and explicitly included the `dist` directory and `Dockerfile` in the published files to ensure all necessary assets are available after publishing.

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code