### PR TITLE
Fix bash escaping vulnerabilities in all SDK agents

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-kit/sdk",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
  - Replace broken regex pattern that used \$& incorrectly
  - Add comprehensive escaping for all bash special characters
  - Escape user prompts, conversation history, and instructions
  - Prevent command injection via special characters like quotes, dollar signs, backticks

  Fixes bash syntax errors when users input special characters

## Description
  - Broken regex replacement pattern `.replace(/[`"$\\]/g, "\\$&")`
  - Missing escaping for conversation history
  - Missing escaping for instructions

  ### Solution
  Implemented comprehensive bash escaping across all 5 agents (Claude, Gemini, Codex,
  Grok, OpenCode):
  - Fixed escaping method with proper character handling
  - Added escaping to all user inputs, history, and instructions
  - Consistent implementation across all agents

  ### Testing
  Tested with inputs containing: `"`, `'`, `$`, `` ` ``, `\`, `!`, newlines, tabs

## Related Issue
N/A (discovered during usage)

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code