### PR TITLE
add support for proxying codex

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibekit",
-  "version": "0.0.1-rc.32",
+  "version": "0.0.1-rc.33",
   "description": "Run Claude Code, Gemini, Codex — or any coding agent — in a clean, isolated sandbox with sensitive data redaction and observability baked in.",
   "main": "dist/cli.js",
   "type": "module",

--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -221,6 +221,11 @@ program
       shouldStartProxy = !proxyManager.isRunning();
     }
     
+    // Set OPENAI_BASE_URL for codex instead of ANTHROPIC_BASE_URL
+    if (proxy) {
+      process.env.OPENAI_BASE_URL = proxy;
+    }
+    
     const agentOptions = {
       proxy: proxy,
       shouldStartProxy: shouldStartProxy,

--- a/packages/cli/src/proxy/server.js
+++ b/packages/cli/src/proxy/server.js
@@ -117,14 +117,25 @@ class ProxyServer {
     let targetUrl;
     try {
       if (req.url.startsWith('/')) {
-        // Relative URL - prepend API base (use custom target if set, otherwise default)
-        const claudeTargetUrl = await getVibeKitProxyTargetURL();
-        const baseUrl = process.env.VIBEKIT_PROXY_TARGET_URL || 
-                        claudeTargetUrl ||
-                        'https://api.anthropic.com';
+        // Detect if this is a codex request based on headers
+        const isCodexRequest = req.headers['originator'] === 'codex_cli_rs' || 
+                              req.headers['user-agent']?.includes('codex') ||
+                              req.url.startsWith('/responses');
         
+        let baseUrl;
         
-        targetUrl = new URL(req.url, baseUrl);
+        if (isCodexRequest) {
+          // Use OpenAI API for codex requests - ensure /v1 is preserved
+          baseUrl = 'https://api.openai.com/v1/';
+        } else {
+          // Use Anthropic API for other requests (Claude)
+          const claudeTargetUrl = await getVibeKitProxyTargetURL();
+          baseUrl = process.env.VIBEKIT_PROXY_TARGET_URL || 
+                    claudeTargetUrl ||
+                    'https://api.anthropic.com';
+        }
+        
+        targetUrl = new URL(req.url.startsWith('/') ? req.url.substring(1) : req.url, baseUrl);
       } else {
         // Absolute URL
         targetUrl = new URL(req.url);
@@ -187,6 +198,11 @@ class ProxyServer {
         let eventBuffer = '';
         const accumulator = this.sseContentAccumulators.get(requestId);
         
+        // Detect if this is a codex/OpenAI request for different handling
+        const isCodexStream = req.headers['originator'] === 'codex_cli_rs' || 
+                             req.url.startsWith('/responses') ||
+                             targetUrl.hostname.includes('openai');
+        
         proxyRes.on('data', (chunk) => {
           const chunkStr = chunk.toString();
           eventBuffer += chunkStr;
@@ -213,27 +229,66 @@ class ProxyServer {
                 }
               });
               
-              // Handle different event types
-              if (event.type === 'content_block_delta' && event.data?.delta?.text) {
-                // Process chunk with buffering for redaction
-                const redactedChunk = this.processChunkWithBuffer(event.data.delta.text, requestId);
-                
-                if (redactedChunk) {
-                  // Forward the redacted chunk immediately
-                  const redactedEventData = {
-                    type: 'content_block_delta',
-                    index: event.data.index || 0,
-                    delta: {
-                      type: 'text_delta',
-                      text: redactedChunk
-                    }
-                  };
-                  
-                  const redactedEvent = `event: content_block_delta\ndata: ${JSON.stringify(redactedEventData)}\n\n`;
-                  res.write(redactedEvent);
+              let shouldRedactAndForward = false;
+              let textContent = '';
+              
+              if (isCodexStream) {
+                // Handle OpenAI streaming format (actual format used by codex)
+                if (event.data?.delta && event.type === 'response.output_text.delta') {
+                  // Handle delta chunks (response.output_text.delta events)
+                  textContent = event.data.delta;
+                  shouldRedactAndForward = true;
+                } else if (event.data?.text && event.type === 'response.output_text.done') {
+                  // Handle complete text (response.output_text.done events) - MUST be redacted
+                  textContent = event.data.text;
+                  shouldRedactAndForward = true;
                 }
-              } else if (event.type === 'content_block_stop') {
-                // Flush any remaining buffer content
+              } else {
+                // Handle Claude streaming format
+                if (event.type === 'content_block_delta' && event.data?.delta?.text) {
+                  textContent = event.data.delta.text;
+                  shouldRedactAndForward = true;
+                }
+              }
+              
+              if (shouldRedactAndForward && textContent) {
+                // For complete text events, directly redact without buffering
+                let redactedContent;
+                if (isCodexStream && event.type === 'response.output_text.done') {
+                  // For complete text events, apply redaction directly - CRITICAL for security
+                  redactedContent = this.redactSensitiveContent(textContent);
+                } else {
+                  // For streaming deltas, use buffering
+                  redactedContent = this.processChunkWithBuffer(textContent, requestId);
+                }
+                
+                if (redactedContent) {
+                  if (isCodexStream) {
+                    // Forward OpenAI format with redacted content
+                    const redactedData = JSON.parse(JSON.stringify(event.data));
+                    if (redactedData.delta) {
+                      redactedData.delta = redactedContent;
+                    } else if (redactedData.text) {
+                      redactedData.text = redactedContent;
+                    }
+                    const redactedEvent = `event: ${event.type}\ndata: ${JSON.stringify(redactedData)}\n\n`;
+                    res.write(redactedEvent);
+                  } else {
+                    // Forward Claude format with redacted content
+                    const redactedEventData = {
+                      type: 'content_block_delta',
+                      index: event.data.index || 0,
+                      delta: {
+                        type: 'text_delta',
+                        text: redactedContent
+                      }
+                    };
+                    const redactedEvent = `event: content_block_delta\ndata: ${JSON.stringify(redactedEventData)}\n\n`;
+                    res.write(redactedEvent);
+                  }
+                }
+              } else if (event.type === 'content_block_stop' && !isCodexStream) {
+                // Claude-specific: Flush any remaining buffer content
                 const finalChunk = this.flushBuffer(requestId);
                 if (finalChunk) {
                   const finalEventData = {
@@ -251,13 +306,27 @@ class ProxyServer {
                 
                 // Forward the stop event
                 res.write(eventData + '\n\n');
-              } else if (event.type === 'message_delta' && event.data?.usage?.output_tokens) {
-                // Store the final usage data to send with our accumulated content
+              } else if (event.type === 'message_delta' && event.data?.usage?.output_tokens && !isCodexStream) {
+                // Claude-specific: Store the final usage data to send with our accumulated content
                 accumulator.totalTokens = event.data.usage.output_tokens;
                 accumulator.messageData = event.data;
                 // Don't forward this yet - we'll send it after our complete content
-              } else {
-                // Forward all other events as-is (message_start, message_stop, content_block_start, ping, etc.)
+              } else if (isCodexStream && (event.type === 'response.completed' || event.data === '[DONE]')) {
+                // OpenAI-specific: Handle end of stream and flush buffer
+                const finalChunk = this.flushBuffer(requestId);
+                if (finalChunk) {
+                  const finalData = {
+                    type: "response.output_text.delta",
+                    delta: finalChunk
+                  };
+                  const finalEvent = `event: response.output_text.delta\ndata: ${JSON.stringify(finalData)}\n\n`;
+                  res.write(finalEvent);
+                }
+                
+                // Forward the completion event
+                res.write(eventData + '\n\n');
+              } else if (!shouldRedactAndForward) {
+                // Forward all other events as-is (only if we didn't already process and forward them)
                 res.write(eventData + '\n\n');
               }
             }


### PR DESCRIPTION
## Description
<!-- A brief summary of the changes in this pull request. -->
This pull request updates the proxy logic in the CLI to better support Codex/OpenAI requests alongside Anthropic/Claude requests, ensuring proper routing and redaction for each API. The main improvements include more accurate detection of Codex/OpenAI requests, tailored streaming event handling, and critical redaction for sensitive content in both streaming and complete responses.

**Proxy routing and API detection:**
* Enhanced detection of Codex/OpenAI requests using headers and URL patterns, allowing the proxy to route requests to the correct API endpoint (`openai.com/v1` for Codex, `anthropic.com` for Claude).

**Streaming event handling and redaction:**
* Implemented distinct streaming event handling for Codex/OpenAI and Claude, including specialized logic to redact sensitive content in both streaming deltas and complete text events. Ensures security by applying redaction directly to complete text events for Codex/OpenAI.
* Added support for forwarding redacted events in the correct format for each API (OpenAI and Claude), and made sure buffer flushing and completion events are handled appropriately for both.

**Environment variable and configuration management:**
* Set `OPENAI_BASE_URL` for Codex requests in the CLI, instead of using `ANTHROPIC_BASE_URL`, to ensure agents connect to the correct endpoint.

**Version update:**
* Bumped the CLI package version from `0.0.1-rc.32` to `0.0.1-rc.33` to reflect these changes.

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code