### PR TITLE
Fix single quote escaping in codex and grok agents

### DIFF
--- a/packages/sdk/src/agents/codex.ts
+++ b/packages/sdk/src/agents/codex.ts
@@ -19,7 +19,7 @@ export class CodexAgent extends BaseAgent {
     return prompt
       .replace(/\\/g, '\\\\')    // Escape backslashes FIRST
       .replace(/"/g, '\\"')      // Escape double quotes
-      .replace(/'/g, "'\\\'")    // Escape single quotes (close quote, escaped quote, reopen)
+      .replace(/'/g, "'\\''")    // Escape single quotes (close quote, escaped quote, reopen)
       .replace(/\$/g, '\\$')     // Escape dollar signs
       .replace(/`/g, '\\`')      // Escape backticks (command substitution)
       .replace(/!/g, '\\!')      // Escape exclamation (history expansion)

--- a/packages/sdk/src/agents/grok.ts
+++ b/packages/sdk/src/agents/grok.ts
@@ -19,7 +19,7 @@ export class GrokAgent extends BaseAgent {
     return prompt
       .replace(/\\/g, '\\\\')    // Escape backslashes FIRST
       .replace(/"/g, '\\"')      // Escape double quotes
-      .replace(/'/g, "'\\\'")    // Escape single quotes (close quote, escaped quote, reopen)
+      .replace(/'/g, "'\\''")    // Escape single quotes (close quote, escaped quote, reopen)
       .replace(/\$/g, '\\$')     // Escape dollar signs
       .replace(/`/g, '\\`')      // Escape backticks (command substitution)
       .replace(/!/g, '\\!')      // Escape exclamation (history expansion)


### PR DESCRIPTION
## Summary
- Fixed incorrect single quote escaping pattern in codex.ts and grok.ts
- Changed from `'\\''` to `'\\'''` to properly escape single quotes in bash

## Problem
The previous PR #202 had an inconsistency where claude.ts, gemini.ts, and opencode.ts correctly used `'\\'''` for single quote escaping, but codex.ts and grok.ts incorrectly used `'\\''`. This could lead to command injection vulnerabilities when users input single quotes.

## Solution
Updated the escaping pattern in both files to match the correct pattern used in the other agent files. This ensures consistent and secure handling of single quotes across all agents.

## Testing
- Verified that all 5 agent files now use the same correct escaping pattern
- The pattern `'\\'''` properly escapes single quotes in bash by: closing the quote, adding an escaped quote, and reopening the quote

## Files Changed
- `packages/sdk/src/agents/codex.ts` - Line 22
- `packages/sdk/src/agents/grok.ts` - Line 22