### PR TITLE
Change sandbox property to public in CloudflareSandboxInstance

### DIFF
--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -48,7 +48,7 @@ export interface CloudflareConfig {
 // Cloudflare implementation
 export class CloudflareSandboxInstance implements SandboxInstance {
   constructor(
-    private sandbox: Sandbox,
+    public sandbox: Sandbox,
     public sandboxId: string,
     private hostname: string,
   ) { }


### PR DESCRIPTION
This affords end-users the flexiblity of calling the sandbox directly (e.g. writeFile, moveFile, etc.)
