### PR TITLE
Change getSandbox method from private to public

### DIFF
--- a/packages/sdk/src/agents/base.ts
+++ b/packages/sdk/src/agents/base.ts
@@ -180,7 +180,7 @@ export abstract class BaseAgent {
   ): AgentCommandConfig;
   protected abstract getDefaultTemplate(): string;
 
-  private async getSandbox(): Promise<SandboxInstance> {
+  public async getSandbox(): Promise<SandboxInstance> {
     if (this.sandboxInstance) return this.sandboxInstance;
 
     if (!this.config.sandboxProvider) {


### PR DESCRIPTION
So end-users can use other provider-specific methods like uploadFile, moveFile, deleteFile, etc. (e.g. for cloudflare)