### PR TITLE
feat: add typed outputs for coding agents

### DIFF
--- a/packages/sdk/src/core/vibekit.ts
+++ b/packages/sdk/src/core/vibekit.ts
@@ -17,6 +17,7 @@ import {
   AgentResponse,
   ExecuteCommandOptions,
   ExecuteCommandResponse,
+  StreamJsonExecuteCommandResponse,
 } from "../types";
 
 export interface VibeKitEvents {
@@ -298,7 +299,7 @@ export class VibeKit extends EventEmitter {
   async executeCommand(
     command: string,
     options: Omit<ExecuteCommandOptions, "callbacks"> = {}
-  ): Promise<ExecuteCommandResponse> {
+  ): Promise<ExecuteCommandResponse | StreamJsonExecuteCommandResponse> {
     if (!this.agent) {
       await this.initializeAgent();
     }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -31,6 +31,7 @@ export type {
   GrokStreamCallbacks,
   AgentResponse,
   ExecuteCommandResponse,
+  StreamJsonExecuteCommandResponse,
   ExecuteCommandOptions,
   CodexConfig,
   CodexResponse,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -144,12 +144,19 @@ export interface AgentResponse {
 
 export interface ExecuteCommandResponse extends AgentResponse {}
 
+// STREAM-JSON EXECUTE COMMAND RESPONSE
+export interface StreamJsonExecuteCommandResponse extends AgentResponse {
+  messages: StreamingMessage[];
+  rawStdout: string;
+}
+
 // EXECUTE COMMAND OPTIONS
 export interface ExecuteCommandOptions {
   timeoutMs?: number;
   background?: boolean;
   callbacks?: StreamCallbacks;
   branch?: string;
+  outputFormat?: 'text' | 'stream-json';
 }
 
 // CODEX CONFIG


### PR DESCRIPTION
Implements typed outputs for all coding agents with unified interfaces and structured streaming messages.

Closes #230

🤖 Generated with [Claude Code](https://claude.ai/code)