### PR TITLE
fix: use base64 encoding to avoid shell escaping issues with JSON content

### DIFF
--- a/packages/cli/src/auth/claude-auth-helper.js
+++ b/packages/cli/src/auth/claude-auth-helper.js
@@ -110,9 +110,13 @@ export class ClaudeAuthHelper {
   static createClaudeWrapper(credentials, args) {
     // Create bash wrapper that deep merges our settings into /root/.claude.json
     const settingsJson = JSON.stringify(credentials.settings);
+    
+    // Use base64 encoding to avoid shell escaping issues with JSON content
+    const settingsBase64 = Buffer.from(settingsJson).toString('base64');
+    
     const mergeScript = `
-      # Write our settings to temp file
-      echo '${settingsJson}' > /tmp/vibekit-settings.json
+      # Write our settings to temp file (decode from base64 to avoid shell escaping issues)
+      echo '${settingsBase64}' | base64 -d > /tmp/vibekit-settings.json
       
       # Create merge script using Node.js (available in Claude container)
       cat > /tmp/merge-settings.js << 'MERGE_EOF'


### PR DESCRIPTION
## Description
Fixed shell escaping issues when JSON contains special characters by encoding settings JSON as base64 before embedding in bash script.

## Related Issue
Fixes #224

## Changes
- Modified `claude-auth-helper.js` to encode JSON settings as base64 before passing to shell
- This prevents bash parsing errors when JSON contains quotes and other special characters
- Resolves the "unexpected EOF while looking for matching quote" error on ARM Ubuntu servers

## Checklist
- [x] I tested my changes
- [x] I reviewed my own code