### PR TITLE
feat: Claude Configuration Injection for Docker Sandboxes

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,5 +1,9 @@
 FROM oven/bun:1
 
+# Build arguments for user/group creation
+ARG HOST_UID=1000
+ARG HOST_GID=1001
+
 # Install system dependencies including build tools for native modules
 RUN apt-get update && apt-get install -y \
     bash \
@@ -11,26 +15,41 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# Create non-root user and group with host UID/GID
+# Remove existing user/group if they conflict, then create vibekit user
+RUN (getent passwd ${HOST_UID} && userdel -r $(getent passwd ${HOST_UID} | cut -d: -f1) || true) && \
+    (getent group ${HOST_GID} && groupdel $(getent group ${HOST_GID} | cut -d: -f1) || true) && \
+    groupadd -g ${HOST_GID} vibekit && \
+    useradd -m -u ${HOST_UID} -g ${HOST_GID} -s /bin/bash vibekit
+
+# Install Node.js for MCP server support
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
+    && apt-get install -y nodejs
+
 # Set up Bun environment
-ENV BUN_INSTALL="/home/.bun"
+ENV BUN_INSTALL="/home/vibekit/.bun"
 ENV PATH="$BUN_INSTALL/bin:$PATH"
 
 # Install coding agents globally
 RUN bun add -g @anthropic-ai/claude-code@latest || echo "Claude CLI install failed"
-RUN bun add -g @openai/codex@latest || echo "Codex CLI install failed"  
+RUN bun add -g @openai/codex@latest || echo "Codex CLI install failed"
 RUN bun add -g @google/gemini-cli@latest || echo "Gemini CLI install failed"
 RUN bun add -g opencode-ai@latest || echo "OpenCode CLI install failed"
 RUN bun add -g @vibe-kit/grok-cli@latest || echo "Grok CLI install failed"
 
 # Try alternative Claude installation
 RUN curl -sSL https://install.anthropic.com | bash || echo "Alternative Claude install failed"
-ENV PATH="/root/.local/bin:$BUN_INSTALL/bin:$PATH"
+ENV PATH="/home/vibekit/.local/bin:$BUN_INSTALL/bin:$PATH"
 
 # Install vibekit CLI globally and create symlink
 RUN bun add -g vibekit || echo "Vibekit install failed"
 
-# Create workspace directory
-RUN mkdir -p /workspace
+# Create workspace directory and Claude directories, set ownership
+RUN mkdir -p /workspace /home/vibekit/.claude && \
+    chown -R vibekit:vibekit /workspace /home/vibekit
+
+# Switch to non-root user
+USER vibekit
 WORKDIR /workspace
 
 # Expose common local development ports


### PR DESCRIPTION
# Claude Configuration Injection for Docker Sandboxes

## Summary

Enables Claude Code to work with full functionality inside Docker containers by automatically injecting user-level configuration files, custom tools, and MCP server environment variables from the host system.

## What This PR Adds

### 1. User-Level Configuration Injection
- Injects `~/.claude/CLAUDE.md` → `/home/vibekit/.claude/CLAUDE.md`
- Injects `~/.claude/{agents,commands,scripts}/*` → `/home/vibekit/.claude/*/`
- Injects `./.claude/{agents,commands,scripts}/*` → `/workspace/.claude/*/`

**Why**: User's personal coding standards and custom workflow tools now work inside containers

### 2. MCP Environment Variable Injection
- Scans `.mcp.json` for `${ENV_VAR}` patterns
- Extracts referenced variables (e.g., `BRAVE_API_KEY`, `ANTHROPIC_API_KEY`)
- Injects only those variables into container

**Security**: Only explicitly referenced env vars are passed—no blind credential exposure

### 3. Project MCP Server Support
- New `extractProjectMcpServers()` function extracts MCP servers from project `.mcp.json`
- Merges with host-level MCP servers (project takes precedence)

### 4. Auto-Executable Scripts
- Automatically `chmod +x` for `.sh` files and scripts in `/commands/`, `/scripts/` directories

### 5. Non-Root User Execution
- Container now runs as `vibekit` user (not root)
- Uses host UID/GID to prevent file ownership conflicts
- All injected files and workspace owned by correct user

**Why**: Prevents permission issues when editing files created inside container

## Technical Implementation

**Method**: Base64-encoded injection script mounted into container
- Avoids Docker's E2BIG limit (~128KB) for large config files
- Prevents shell injection from special characters
- Read-only mount (`:ro`) for security

**Graceful Degradation**: Silently skips injection if config files don't exist—no errors, no crashes

## Files Changed

- `packages/cli/src/sandbox/docker-sandbox.js` (+190 lines)
  - `injectClaudeFiles()` - File injection logic
  - `injectEnvironmentVariables()` - MCP env var extraction
  - `extractEnvVarsFromMcpConfig()` - Recursive env var pattern matching
  - `createFileInjectionScript()` - Base64-encoded script generation

- `packages/cli/src/auth/claude-auth-helper.js` (+53 lines)
  - `extractProjectMcpServers()` - Project-level MCP server extraction
  - Updated `generateClaudeSettings()` - Merge host + project MCP servers
  - Sanitized MCP server logging (security)

- `packages/cli/Dockerfile` (+23/-4 lines)
  - Added non-root user creation with host UID/GID mapping
  - Updated all paths from `/root/` to `/home/vibekit/`
  - Added Node.js for MCP server support
  - Created `/home/vibekit/.claude` directory

## Commits

1. `921a975` - feat(docker): add Claude configuration and credential injection support
2. `3101ed2` - fix(auth): sanitize MCP server logging to avoid exposing configuration details
3. `38c0a39` - fix(docker): automatically set executable permissions for injected scripts

## Testing

- ✅ File injection with large CLAUDE.md (>100KB)
- ✅ MCP server environment variable extraction from `.mcp.json`
- ✅ Executable permissions for scripts in `.claude/commands/` and `.claude/scripts/`
- ✅ Graceful handling when config files don't exist
- ✅ Special characters in configuration (quotes, newlines, JSON)
- ✅ Non-root user execution (no permission errors)
- ✅ File ownership matches host UID/GID

## Before This PR

Claude Code works in containers but:
- No user-level `CLAUDE.md` (loses personal coding preferences)
- No custom tools from `.claude/{agents,commands,scripts}`
- MCP servers fail (missing API keys/credentials)
- Files created as root (permission conflicts on host)

## After This PR

- ✅ User configuration automatically available
- ✅ Custom tools work immediately
- ✅ MCP servers functional (Brave Search, context7, etc.)
- ✅ Zero setup required
- ✅ Correct file ownership (no permission issues)

## Security Notes

- Only env vars explicitly referenced in `.mcp.json` are injected
- Injection script mounted read-only (`:ro`)
- Temporary files cleaned up after container starts
- No credentials in container images or logs
- Non-root execution follows security best practices
