### PR TITLE
feat: add Tenki sandbox provider (@vibe-kit/tenki)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -64,7 +64,8 @@
               "supported-sandboxes/e2b",
               "supported-sandboxes/flyio",
               "supported-sandboxes/modal",
-              "supported-sandboxes/northflank"
+              "supported-sandboxes/northflank",
+              "supported-sandboxes/tenki"
             ]
           },
           {

--- a/docs/supported-sandboxes/tenki.mdx
+++ b/docs/supported-sandboxes/tenki.mdx
@@ -1,0 +1,129 @@
+---
+title: 'Tenki'
+description: 'Configure VibeKit with Tenki disposable microVM sandboxes'
+---
+
+[Tenki](https://tenki.cloud) runs coding agents inside disposable Linux microVMs with per-second billing, public preview URLs, and pause/resume. It is a good fit for VibeKit's "run an agent safely, watch it remotely" workflow, and boots agents on Tenki's default base image with no image maintenance on your side.
+
+## Installation
+
+```bash
+npm install @vibe-kit/tenki
+```
+
+## Prerequisites
+
+1. Sign up for Tenki and create a workspace at [tenki.cloud](https://tenki.cloud).
+2. Create an API key (prefixed `tk_`) in your account settings.
+3. Set it as an environment variable:
+
+```bash
+export TENKI_AUTH_TOKEN=tk_your_key_here
+```
+
+The SDK also accepts `TENKI_API_KEY` as a fallback.
+
+## Configuration
+
+VibeKit uses a builder pattern with method chaining. Configure your Tenki provider and VibeKit instance:
+
+```typescript
+import { VibeKit } from "@vibe-kit/sdk";
+import { createTenkiProvider } from "@vibe-kit/tenki";
+
+// Create the Tenki provider
+const tenkiProvider = createTenkiProvider({
+  apiKey: process.env.TENKI_AUTH_TOKEN!, // optional; falls back to TENKI_AUTH_TOKEN / TENKI_API_KEY
+  cpuCores: 2, // optional
+  memoryMb: 4096, // optional
+});
+
+// Create the VibeKit instance with the provider
+const vibeKit = new VibeKit()
+  .withAgent({
+    type: "claude",
+    provider: "anthropic",
+    apiKey: process.env.ANTHROPIC_API_KEY!,
+    model: "claude-sonnet-4-20250514",
+  })
+  .withSandbox(tenkiProvider)
+  .withWorkingDirectory("/var/vibe0") // optional
+  .withSecrets({
+    NODE_ENV: "development",
+  });
+
+// Generate code
+const result = await vibeKit.generateCode({
+  prompt: "Create a REST API with Express.js",
+  mode: "ask",
+});
+
+// Execute commands in the sandbox
+await vibeKit.executeCommand("npm install && npm test");
+
+// Start a dev server in the background and get its public URL
+await vibeKit.executeCommand("npm run dev", { background: true });
+const url = await vibeKit.getHost(3000);
+console.log(`Service available at: ${url}`);
+
+// Clean up
+await vibeKit.kill();
+```
+
+## Configuration Options
+
+`createTenkiProvider` accepts:
+
+### Optional Options
+
+- **`apiKey`** (string): your Tenki API key (`tk_…`). Falls back to `TENKI_AUTH_TOKEN`, then `TENKI_API_KEY`.
+- **`baseUrl`** (string): override the Tenki API endpoint (defaults to `https://api.tenki.cloud`).
+- **`workspaceId`** (string): Tenki workspace id. Auto-resolved from your first workspace when omitted.
+- **`projectId`** (string): Tenki project id. Auto-resolved from the workspace's first project when omitted.
+- **`cpuCores`** (number): vCPU cores for the sandbox.
+- **`memoryMb`** (number): memory in MB for the sandbox.
+- **`maxDurationMs`** (number): hard cap on total sandbox lifetime — a backstop so an abandoned sandbox self-terminates.
+- **`idleTimeoutMinutes`** (number): auto-stop after N idle minutes. Keep it longer than your longest single task.
+- **`waitTimeoutMs`** (number): how long `create()` waits for readiness; bounds provisioning independently of per-command timeouts.
+- **`sticky`** (boolean): keep the sandbox persistent/long-lived, enabling reliable `resume`.
+- **`image`** (string | object): boot from a pre-built **Tenki registry** image. This is a Tenki registry reference, **not** a Docker Hub image. When set, the agent CLI is assumed to be pre-installed.
+- **`snapshotId`** (string): boot from a Tenki snapshot. Same skip-install behavior as `image`.
+- **`installAgent`** (boolean): install the requested agent's CLI at create time on Tenki's default base image. Defaults to `true` unless `image`/`snapshotId` is provided.
+
+## How it works
+
+By default the provider boots Tenki's stock base image and installs the requested agent's CLI at create time — `@anthropic-ai/claude-code`, `@openai/codex`, `@google/gemini-cli`, `opencode-ai`, or `@vibe-kit/grok-cli` (the same packages used by the prebuilt VibeKit images). To skip the per-create install, pre-bake those CLIs into a Tenki registry image or snapshot and pass it via `image` / `snapshotId`.
+
+## Features
+
+- Runtime agent-CLI installation on Tenki's default base image (no image maintenance)
+- Optional custom Tenki registry image / snapshot
+- Background command execution with streamed stdout/stderr
+- Preview URLs via exposed ports (`getHost`)
+- Pause / resume of long-lived sandboxes
+- Environment variable injection and custom working directory
+
+## ENV variables and secrets
+
+```bash
+# Required Tenki credential
+TENKI_AUTH_TOKEN=tk_your_key_here
+
+# Agent API keys (as needed)
+ANTHROPIC_API_KEY=your_anthropic_key
+OPENAI_API_KEY=your_openai_key
+GEMINI_API_KEY=your_gemini_key
+
+# Optional GitHub integration
+GITHUB_TOKEN=your_github_token_here
+```
+
+## System Requirements
+
+- **Node.js 18+**
+- **Tenki account** with a workspace and API key
+
+## Support
+
+- **Tenki Platform**: [Tenki Documentation](https://tenki.cloud/docs)
+- **VibeKit Integration**: open an issue on [GitHub](https://github.com/superagent-ai/vibekit/issues)

--- a/docs/supported-sandboxes/tenki.mdx
+++ b/docs/supported-sandboxes/tenki.mdx
@@ -44,7 +44,7 @@ const vibeKit = new VibeKit()
     type: "claude",
     provider: "anthropic",
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    model: "claude-sonnet-4-20250514",
+    model: "sonnet", // alias for the current Sonnet; a pinned dated model can 404
   })
   .withSandbox(tenkiProvider)
   .withWorkingDirectory("/var/vibe0") // optional
@@ -52,11 +52,10 @@ const vibeKit = new VibeKit()
     NODE_ENV: "development",
   });
 
-// Generate code
-const result = await vibeKit.generateCode({
-  prompt: "Create a REST API with Express.js",
-  mode: "ask",
-});
+// Run a command in the sandbox and read its output
+// (executeCommand is VibeKit's supported entrypoint; generateCode is deprecated)
+const result = await vibeKit.executeCommand("echo 'hello from the sandbox'");
+console.log(result.stdout);
 
 // Execute commands in the sandbox
 await vibeKit.executeCommand("npm install && npm test");

--- a/docs/supported-sandboxes/tenki.mdx
+++ b/docs/supported-sandboxes/tenki.mdx
@@ -79,8 +79,7 @@ try {
 
 - **`apiKey`** (string): your Tenki API key (`tk_…`). Falls back to `TENKI_AUTH_TOKEN`, then `TENKI_API_KEY`.
 - **`baseUrl`** (string): override the Tenki API endpoint (defaults to `https://api.tenki.cloud`).
-- **`workspaceId`** (string): Tenki workspace id. Auto-resolved from your first workspace when omitted.
-- **`projectId`** (string): Tenki project id. Auto-resolved from the workspace's first project when omitted.
+- **`workspaceId`** (string): explicit workspace scope — only needed for service-token callers; a workspace API key (`tk_…`) infers it automatically.
 - **`cpuCores`** (number): vCPU cores for the sandbox.
 - **`memoryMb`** (number): memory in MB for the sandbox.
 - **`maxDurationMs`** (number): hard cap on total sandbox lifetime — a backstop so an abandoned sandbox self-terminates.

--- a/docs/supported-sandboxes/tenki.mdx
+++ b/docs/supported-sandboxes/tenki.mdx
@@ -52,21 +52,23 @@ const vibeKit = new VibeKit()
     NODE_ENV: "development",
   });
 
-// Run a command in the sandbox and read its output
-// (executeCommand is VibeKit's supported entrypoint; generateCode is deprecated)
-const result = await vibeKit.executeCommand("echo 'hello from the sandbox'");
-console.log(result.stdout);
+try {
+  // Run a command in the sandbox and read its output
+  // (executeCommand is VibeKit's supported entrypoint; generateCode is deprecated)
+  const result = await vibeKit.executeCommand("echo 'hello from the sandbox'");
+  console.log(result.stdout);
 
-// Execute commands in the sandbox
-await vibeKit.executeCommand("npm install && npm test");
+  // Execute commands in the sandbox
+  await vibeKit.executeCommand("npm install && npm test");
 
-// Start a dev server in the background and get its public URL
-await vibeKit.executeCommand("npm run dev", { background: true });
-const url = await vibeKit.getHost(3000);
-console.log(`Service available at: ${url}`);
-
-// Clean up
-await vibeKit.kill();
+  // Start a dev server in the background and get its public URL
+  await vibeKit.executeCommand("npm run dev", { background: true });
+  const url = await vibeKit.getHost(3000);
+  console.log(`Service available at: ${url}`);
+} finally {
+  // Always tear the sandbox down, even if a command or getHost() throws.
+  await vibeKit.kill();
+}
 ```
 
 ## Configuration Options

--- a/package-lock.json
+++ b/package-lock.json
@@ -7359,15 +7359,15 @@
             }
         },
         "node_modules/@tenkicloud/sandbox": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.4.0.tgz",
-            "integrity": "sha512-p9GiQutfqEhEEAQlEOph/wuP2Vk0kDof4GjhIvnV96TbvzoqPFp1pD6iEjUcJMri6sJsEXBGf0Grsyl+X52GiA==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.5.4.tgz",
+            "integrity": "sha512-U/oV8TAB1rjpXHuo9DIrpxnd2tlO2MojNjzLjqKgx4+zkD4NjgpR6QzRv5awoXib0DND3bnu0qoQCIgsfcXTCw==",
             "license": "MIT",
             "dependencies": {
                 "@bufbuild/protobuf": "2.12.1",
                 "@connectrpc/connect": "2.1.2",
                 "@connectrpc/connect-node": "2.1.2",
-                "ws": "8.21.0"
+                "ws": "8.21.1"
             },
             "engines": {
                 "node": ">=18"
@@ -17943,7 +17943,6 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -22085,9 +22084,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -22699,7 +22698,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@tenkicloud/sandbox": "^0.4.0"
+                "@tenkicloud/sandbox": "^0.5.4"
             },
             "devDependencies": {
                 "@types/node": "^22.15.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -385,6 +385,7 @@
             "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.908.0.tgz",
             "integrity": "sha512-c/89iG3of8UEiWbRK014DoHLy8PLLTJtM9IvYLPsvrf83kpV2P/K9WrdbjW4h6e5qt9XPgfNTZ8U607mt7pdmA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha1-browser": "5.2.0",
                 "@aws-crypto/sha256-browser": "5.2.0",
@@ -1100,6 +1101,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
             "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.3",
@@ -1641,10 +1643,11 @@
             }
         },
         "node_modules/@bufbuild/protobuf": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.9.0.tgz",
-            "integrity": "sha512-rnJenoStJ8nvmt9Gzye8nkYd6V22xUAnu4086ER7h1zJ508vStko4pMvDeQ446ilDTFpV5wnoc5YS7XvMwwMqA==",
-            "license": "(Apache-2.0 AND BSD-3-Clause)"
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+            "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+            "license": "(Apache-2.0 AND BSD-3-Clause)",
+            "peer": true
         },
         "node_modules/@cloudflare/containers": {
             "version": "0.0.25",
@@ -1780,6 +1783,7 @@
             "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
             "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "peerDependencies": {
                 "@bufbuild/protobuf": "^2.2.0"
             }
@@ -2722,7 +2726,6 @@
             "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.3.3.tgz",
             "integrity": "sha512-vArVDtrvdzFewu1hnjUm4jX1NBITlSCeO81EdWq676MxQbyxsGcDPAgohaSA+Wvr4HjPSvsg2/1s2zYxUtXebg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -2738,7 +2741,6 @@
             "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.2.1.tgz",
             "integrity": "sha512-inPeksRLq+j3ArnuGOzQPQE//YrhezQG0+9Y9yizScBN2qatJ78fIByhEgKdNAbtguDCn4RPxmEhcrePwHxs4A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jsdevtools/ono": "^7.1.3",
                 "@types/json-schema": "^7.0.15",
@@ -2757,7 +2759,6 @@
             "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.87.0.tgz",
             "integrity": "sha512-BZmiwvkXsMRlv6PTFuEoIsvIuT3nv5t5VN91pJapdXwnOVolA4u8BiwmLPR0cXtVeNdpUndgnD7DWMPjpVJ0fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@hey-api/codegen-core": "^0.3.3",
                 "@hey-api/json-schema-ref-parser": "1.2.1",
@@ -2786,7 +2787,6 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
             "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=20"
             }
@@ -2796,7 +2796,6 @@
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
             "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2809,7 +2808,6 @@
             "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
             "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "default-browser": "^5.2.1",
                 "define-lazy-prop": "^3.0.0",
@@ -2828,7 +2826,6 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
             "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -4052,8 +4049,7 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
             "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@jsdoc/salty": {
             "version": "0.2.9",
@@ -4138,6 +4134,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -4482,6 +4479,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -7360,6 +7358,44 @@
                 "tailwindcss": "4.1.14"
             }
         },
+        "node_modules/@tenkicloud/sandbox": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@tenkicloud/sandbox/-/sandbox-0.4.0.tgz",
+            "integrity": "sha512-p9GiQutfqEhEEAQlEOph/wuP2Vk0kDof4GjhIvnV96TbvzoqPFp1pD6iEjUcJMri6sJsEXBGf0Grsyl+X52GiA==",
+            "license": "MIT",
+            "dependencies": {
+                "@bufbuild/protobuf": "2.12.1",
+                "@connectrpc/connect": "2.1.2",
+                "@connectrpc/connect-node": "2.1.2",
+                "ws": "8.21.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@tenkicloud/sandbox/node_modules/@connectrpc/connect": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+            "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "peerDependencies": {
+                "@bufbuild/protobuf": "^2.7.0"
+            }
+        },
+        "node_modules/@tenkicloud/sandbox/node_modules/@connectrpc/connect-node": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.2.tgz",
+            "integrity": "sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "@bufbuild/protobuf": "^2.7.0",
+                "@connectrpc/connect": "2.1.2"
+            }
+        },
         "node_modules/@tybys/wasm-util": {
             "version": "0.10.1",
             "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -7601,6 +7637,7 @@
             "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
             "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/linkify-it": "^5",
                 "@types/mdurl": "^2"
@@ -7643,6 +7680,7 @@
             "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.0.2"
             }
@@ -7653,6 +7691,7 @@
             "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -7756,6 +7795,7 @@
             "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.46.1",
                 "@typescript-eslint/types": "8.46.1",
@@ -8251,6 +8291,10 @@
             "resolved": "packages/sdk",
             "link": true
         },
+        "node_modules/@vibe-kit/tenki": {
+            "resolved": "packages/tenki",
+            "link": true
+        },
         "node_modules/@vitest/coverage-v8": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
@@ -8485,6 +8529,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -8628,7 +8673,6 @@
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
             "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -9381,6 +9425,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.8.9",
                 "caniuse-lite": "^1.0.30001746",
@@ -9441,6 +9486,7 @@
             "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
             },
@@ -9467,7 +9513,6 @@
             "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
             "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "run-applescript": "^7.0.0"
             },
@@ -9508,7 +9553,6 @@
             "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.1.tgz",
             "integrity": "sha512-LcWQ01LT9tkoUINHgpIOv3mMs+Abv7oVCrtpMRi1PaapVEpWoMga5WuT7/DqFTu7URP9ftbOmimNw1KNIGh9DQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "chokidar": "^4.0.3",
                 "confbox": "^0.2.2",
@@ -9536,15 +9580,13 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
             "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/c12/node_modules/pkg-types": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
             "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "confbox": "^0.2.2",
                 "exsolve": "^1.0.7",
@@ -9781,7 +9823,6 @@
             "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
             "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "consola": "^3.2.3"
             }
@@ -10078,7 +10119,6 @@
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "color-support": "bin.js"
             }
@@ -10539,7 +10579,6 @@
             "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
             "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "bundle-name": "^4.1.0",
                 "default-browser-id": "^5.0.0"
@@ -10556,7 +10595,6 @@
             "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
             "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -10648,8 +10686,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
             "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
@@ -11080,6 +11117,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -11240,6 +11278,7 @@
             "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -11414,6 +11453,7 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -12778,7 +12818,6 @@
             "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
             "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "citty": "^0.1.6",
                 "consola": "^3.4.0",
@@ -13096,6 +13135,7 @@
             "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
             "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
@@ -13916,7 +13956,6 @@
             "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
             "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "is-docker": "^3.0.0"
             },
@@ -13935,7 +13974,6 @@
             "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
             "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -15846,6 +15884,216 @@
                 "lightningcss-win32-x64-msvc": "1.30.1"
             }
         },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+            "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+            "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+            "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+            "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+            "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+            "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+            "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+            "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+            "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+            "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/lilconfig": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -15997,6 +16245,7 @@
             "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/parser": "^7.25.4",
                 "@babel/types": "^7.25.4",
@@ -16032,6 +16281,7 @@
             "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
             "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
@@ -17001,8 +17251,7 @@
             "version": "1.6.7",
             "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
             "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/node-forge": {
             "version": "1.3.1",
@@ -17078,7 +17327,6 @@
             "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
             "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "citty": "^0.1.6",
                 "consola": "^3.4.2",
@@ -17097,15 +17345,13 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
             "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/nypm/node_modules/pkg-types": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
             "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "confbox": "^0.2.2",
                 "exsolve": "^1.0.7",
@@ -17117,7 +17363,6 @@
             "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
             "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -17685,8 +17930,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
             "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -17699,6 +17943,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -17997,6 +18242,7 @@
             "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -18278,7 +18524,6 @@
             "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
             "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "defu": "^6.1.4",
                 "destr": "^2.0.3"
@@ -18289,6 +18534,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
             "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18341,6 +18587,7 @@
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -18549,7 +18796,8 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -18828,7 +19076,6 @@
             "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
             "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -18944,8 +19191,7 @@
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
             "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "7.7.3",
@@ -20441,6 +20687,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -20521,6 +20768,7 @@
             "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "defu": "^6.1.4",
                 "exsolve": "^1.0.7",
@@ -20694,6 +20942,7 @@
             "integrity": "sha512-EYZR+OpIXp9Y1eG1iueg8KRsY8TuT8VNgnanZ0uA3STqhHQTLwbl+WX76/9X5OY12yQubymBpaBSmMPkSTQcKA==",
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
             },
@@ -20803,6 +21052,7 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -21208,6 +21458,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "workerd": "bin/workerd"
             },
@@ -21834,10 +22085,11 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -21859,7 +22111,6 @@
             "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
             "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "is-wsl": "^3.1.0"
             },
@@ -21875,7 +22126,6 @@
             "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
             "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "is-inside-container": "^1.0.0"
             },
@@ -22079,6 +22329,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
             "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -22296,6 +22547,7 @@
             "dev": true,
             "inBundle": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -22425,6 +22677,7 @@
         "packages/sdk": {
             "name": "@vibe-kit/sdk",
             "version": "0.0.70",
+            "peer": true,
             "dependencies": {
                 "@ai-sdk/anthropic": "^2.0.27",
                 "@ai-sdk/openai": "^2.0.52",
@@ -22439,6 +22692,22 @@
                 "@types/node": "^22.15.18",
                 "tsup": "^8.4.0",
                 "typescript": "^5.8.3"
+            }
+        },
+        "packages/tenki": {
+            "name": "@vibe-kit/tenki",
+            "version": "0.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "@tenkicloud/sandbox": "^0.4.0"
+            },
+            "devDependencies": {
+                "@types/node": "^22.15.18",
+                "tsup": "^8.4.0",
+                "typescript": "^5.8.3"
+            },
+            "peerDependencies": {
+                "@vibe-kit/sdk": "*"
             }
         }
     }

--- a/packages/tenki/README.md
+++ b/packages/tenki/README.md
@@ -46,21 +46,23 @@ const vibeKit = new VibeKit()
     NODE_ENV: "development",
   });
 
-// Run a command in the sandbox and read its output
-// (executeCommand is VibeKit's supported entrypoint; generateCode is deprecated)
-const result = await vibeKit.executeCommand("echo 'hello from the sandbox'");
-console.log(result.stdout);
+try {
+  // Run a command in the sandbox and read its output
+  // (executeCommand is VibeKit's supported entrypoint; generateCode is deprecated)
+  const result = await vibeKit.executeCommand("echo 'hello from the sandbox'");
+  console.log(result.stdout);
 
-// Execute commands in the sandbox
-await vibeKit.executeCommand("npm install && npm test");
+  // Execute commands in the sandbox
+  await vibeKit.executeCommand("npm install && npm test");
 
-// Start a dev server in the background and get its public URL
-await vibeKit.executeCommand("npm run dev", { background: true });
-const url = await vibeKit.getHost(3000);
-console.log(`Service available at: ${url}`);
-
-// Clean up
-await vibeKit.kill();
+  // Start a dev server in the background and get its public URL
+  await vibeKit.executeCommand("npm run dev", { background: true });
+  const url = await vibeKit.getHost(3000);
+  console.log(`Service available at: ${url}`);
+} finally {
+  // Always tear the sandbox down, even if a command or getHost() throws.
+  await vibeKit.kill();
+}
 ```
 
 ## Configuration

--- a/packages/tenki/README.md
+++ b/packages/tenki/README.md
@@ -37,7 +37,7 @@ const vibeKit = new VibeKit()
     type: "claude",
     provider: "anthropic",
     apiKey: process.env.ANTHROPIC_API_KEY!,
-    model: "claude-sonnet-4-20250514",
+    model: "sonnet", // alias for the current Sonnet; a pinned dated model can 404
   })
   .withSandbox(tenkiProvider)
   .withWorkingDirectory("/var/vibe0") // optional
@@ -46,11 +46,10 @@ const vibeKit = new VibeKit()
     NODE_ENV: "development",
   });
 
-// Generate code
-const result = await vibeKit.generateCode({
-  prompt: "Create a REST API with Express.js",
-  mode: "ask",
-});
+// Run a command in the sandbox and read its output
+// (executeCommand is VibeKit's supported entrypoint; generateCode is deprecated)
+const result = await vibeKit.executeCommand("echo 'hello from the sandbox'");
+console.log(result.stdout);
 
 // Execute commands in the sandbox
 await vibeKit.executeCommand("npm install && npm test");

--- a/packages/tenki/README.md
+++ b/packages/tenki/README.md
@@ -1,0 +1,106 @@
+# @vibe-kit/tenki
+
+[Tenki](https://tenki.cloud) sandbox provider for VibeKit. Runs coding agents inside Tenki's disposable Linux microVMs, with per-second billing, preview URLs, and pause/resume.
+
+## Installation
+
+```bash
+npm install @vibe-kit/tenki
+```
+
+## Prerequisites
+
+1. Sign up for Tenki and create a workspace at [tenki.cloud](https://tenki.cloud) (comes with free monthly credit).
+2. Create an API key (prefixed `tk_`) in your account settings.
+3. Set it as an environment variable:
+
+```bash
+export TENKI_AUTH_TOKEN=tk_your_key_here
+```
+
+## Usage
+
+```typescript
+import { VibeKit } from "@vibe-kit/sdk";
+import { createTenkiProvider } from "@vibe-kit/tenki";
+
+// Create the Tenki provider with configuration
+const tenkiProvider = createTenkiProvider({
+  apiKey: process.env.TENKI_AUTH_TOKEN!, // optional; falls back to TENKI_AUTH_TOKEN / TENKI_API_KEY
+  cpuCores: 2, // optional
+  memoryMb: 4096, // optional
+});
+
+// Create the VibeKit instance with the provider
+const vibeKit = new VibeKit()
+  .withAgent({
+    type: "claude",
+    provider: "anthropic",
+    apiKey: process.env.ANTHROPIC_API_KEY!,
+    model: "claude-sonnet-4-20250514",
+  })
+  .withSandbox(tenkiProvider)
+  .withWorkingDirectory("/var/vibe0") // optional
+  .withSecrets({
+    // Any environment variables for the sandbox
+    NODE_ENV: "development",
+  });
+
+// Generate code
+const result = await vibeKit.generateCode({
+  prompt: "Create a REST API with Express.js",
+  mode: "ask",
+});
+
+// Execute commands in the sandbox
+await vibeKit.executeCommand("npm install && npm test");
+
+// Start a dev server in the background and get its public URL
+await vibeKit.executeCommand("npm run dev", { background: true });
+const url = await vibeKit.getHost(3000);
+console.log(`Service available at: ${url}`);
+
+// Clean up
+await vibeKit.kill();
+```
+
+## Configuration
+
+`createTenkiProvider` accepts:
+
+- **`apiKey`** (string, optional): your Tenki API key (`tk_…`). Falls back to `TENKI_AUTH_TOKEN`, then `TENKI_API_KEY`.
+- **`baseUrl`** (string, optional): override the Tenki API endpoint (defaults to `https://api.tenki.cloud`).
+- **`workspaceId`** (string, optional): Tenki workspace id. Auto-resolved from your first workspace when omitted.
+- **`projectId`** (string, optional): Tenki project id. Auto-resolved from the workspace's first project when omitted.
+- **`cpuCores`** (number, optional): vCPU cores for the sandbox.
+- **`memoryMb`** (number, optional): memory in MB for the sandbox.
+- **`maxDurationMs`** (number, optional): hard cap on total sandbox lifetime — a backstop so an abandoned sandbox self-terminates.
+- **`idleTimeoutMinutes`** (number, optional): auto-stop after N idle minutes. Keep it longer than your longest single task.
+- **`waitTimeoutMs`** (number, optional): how long `create()` waits for readiness; bounds provisioning independently of per-command timeouts.
+- **`sticky`** (boolean, optional): keep the sandbox persistent/long-lived, enabling reliable `resume`.
+- **`image`** (string | object, optional): boot from a pre-built **Tenki registry** image. This is a Tenki registry reference, **not** a Docker Hub image. When set, the agent CLI is assumed to be pre-installed.
+- **`snapshotId`** (string, optional): boot from a Tenki snapshot. Same skip-install behavior as `image`.
+- **`installAgent`** (boolean, optional): install the requested agent's CLI at create time on Tenki's default base image. Defaults to `true` unless `image`/`snapshotId` is supplied.
+
+## How it works
+
+By default this provider boots Tenki's stock base image and installs the requested agent's CLI at create time (`@anthropic-ai/claude-code`, `@openai/codex`, `@google/gemini-cli`, `opencode-ai`, or `@vibe-kit/grok-cli` — the same packages used by the prebuilt VibeKit images). To avoid the per-create install, pre-bake those CLIs into a Tenki registry image or snapshot and pass it via `image` / `snapshotId`.
+
+## Features
+
+- Runtime agent-CLI installation on Tenki's default base image (no image maintenance required)
+- Optional custom Tenki registry image / snapshot
+- Background command execution with streamed stdout/stderr
+- Preview URLs via exposed ports (`getHost`)
+- Pause / resume of long-lived sandboxes
+- Environment variable injection
+- Custom working directory
+
+## Requirements
+
+- Node.js 18+
+- A Tenki account, workspace, and API key
+
+## License
+
+MIT

--- a/packages/tenki/README.md
+++ b/packages/tenki/README.md
@@ -71,8 +71,7 @@ try {
 
 - **`apiKey`** (string, optional): your Tenki API key (`tk_…`). Falls back to `TENKI_AUTH_TOKEN`, then `TENKI_API_KEY`.
 - **`baseUrl`** (string, optional): override the Tenki API endpoint (defaults to `https://api.tenki.cloud`).
-- **`workspaceId`** (string, optional): Tenki workspace id. Auto-resolved from your first workspace when omitted.
-- **`projectId`** (string, optional): Tenki project id. Auto-resolved from the workspace's first project when omitted.
+- **`workspaceId`** (string, optional): explicit workspace scope — only needed for service-token callers; a workspace API key (`tk_…`) infers it automatically.
 - **`cpuCores`** (number, optional): vCPU cores for the sandbox.
 - **`memoryMb`** (number, optional): memory in MB for the sandbox.
 - **`maxDurationMs`** (number, optional): hard cap on total sandbox lifetime — a backstop so an abandoned sandbox self-terminates.

--- a/packages/tenki/package.json
+++ b/packages/tenki/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@vibe-kit/tenki",
+  "version": "0.0.1",
+  "description": "Tenki sandbox provider for VibeKit",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "dev": "tsup src/index.ts --watch",
+    "type-check": "tsc --noEmit"
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "@vibe-kit/sdk": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.18",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "@tenkicloud/sandbox": "^0.4.0"
+  }
+}

--- a/packages/tenki/package.json
+++ b/packages/tenki/package.json
@@ -27,6 +27,6 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@tenkicloud/sandbox": "^0.4.0"
+    "@tenkicloud/sandbox": "^0.5.4"
   }
 }

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -1,0 +1,378 @@
+import {
+  TenkiSandbox,
+  isSuccess,
+  stderrText,
+  stdoutText,
+  type CreateOptions,
+  type Session,
+} from "@tenkicloud/sandbox";
+
+// Define the interfaces we need from the SDK.
+// (Mirrors the shared contract in @vibe-kit/sdk, duplicated per provider to
+// match the pattern used by @vibe-kit/daytona and @vibe-kit/blaxel.)
+export interface SandboxExecutionResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface SandboxCommandOptions {
+  timeoutMs?: number;
+  background?: boolean;
+  onStdout?: (data: string) => void;
+  onStderr?: (data: string) => void;
+}
+
+export interface SandboxCommands {
+  run(
+    command: string,
+    options?: SandboxCommandOptions
+  ): Promise<SandboxExecutionResult>;
+}
+
+export interface SandboxInstance {
+  sandboxId: string;
+  commands: SandboxCommands;
+  kill(): Promise<void>;
+  pause(): Promise<void>;
+  getHost(port: number): Promise<string>;
+}
+
+export interface SandboxProvider {
+  create(
+    envs?: Record<string, string>,
+    agentType?: AgentType,
+    workingDirectory?: string
+  ): Promise<SandboxInstance>;
+  resume(sandboxId: string): Promise<SandboxInstance>;
+}
+
+export type AgentType = "codex" | "claude" | "opencode" | "gemini" | "grok";
+
+export interface TenkiConfig {
+  /**
+   * Tenki API key (`tk_…`). When omitted, the SDK falls back to the
+   * `TENKI_AUTH_TOKEN` / `TENKI_API_KEY` environment variables.
+   */
+  apiKey?: string;
+  /** Override the Tenki API base URL (defaults to https://api.tenki.cloud). */
+  baseUrl?: string;
+  /** Tenki workspace id. Auto-resolved from the account's first workspace when omitted. */
+  workspaceId?: string;
+  /** Tenki project id. Auto-resolved from the workspace's first project when omitted. */
+  projectId?: string;
+  /**
+   * Boot from a pre-built Tenki registry image (ref string or image object).
+   * NOTE: this is a Tenki registry reference, NOT a Docker Hub image. When set,
+   * the agent CLI is assumed to be pre-installed and runtime install is skipped.
+   */
+  image?: CreateOptions["image"];
+  /** Boot from a Tenki snapshot id. Same skip-install behavior as `image`. */
+  snapshotId?: string;
+  /** vCPU cores for the sandbox (defaults to the Tenki service default). */
+  cpuCores?: number;
+  /** Memory in MB for the sandbox (defaults to the Tenki service default). */
+  memoryMb?: number;
+  /**
+   * Hard cap on total sandbox lifetime (ms) — a backstop so an abandoned or
+   * leaked sandbox self-terminates. Defaults to the Tenki service default; set
+   * it longer than your longest expected run.
+   */
+  maxDurationMs?: number;
+  /**
+   * Auto-stop the sandbox after this many idle minutes. Defaults to the Tenki
+   * service default; keep it longer than your longest single task so active
+   * work is not paused mid-run.
+   */
+  idleTimeoutMinutes?: number;
+  /**
+   * How long create() waits for the sandbox to become ready (ms). Bounds
+   * provisioning independently of per-command timeouts.
+   */
+  waitTimeoutMs?: number;
+  /** Keep the sandbox persistent/long-lived (enables reliable `resume`). */
+  sticky?: boolean;
+  /**
+   * Install the requested agent's CLI at create() time on Tenki's default base
+   * image. Defaults to `true` unless a custom `image`/`snapshotId` is provided
+   * (in which case the CLI is assumed to be baked in).
+   */
+  installAgent?: boolean;
+}
+
+// Agent CLI packages, sourced from assets/dockerfiles/Dockerfile.<agent> in this
+// repo — the same packages baked into the prebuilt superagentai/vibekit-* images.
+const AGENT_CLI_PACKAGES: Record<AgentType, string> = {
+  claude: "@anthropic-ai/claude-code@latest",
+  codex: "@openai/codex@latest",
+  gemini: "@google/gemini-cli",
+  opencode: "opencode-ai@latest",
+  grok: "@vibe-kit/grok-cli@latest",
+};
+
+// Bash that ensures the requested agent's CLI is present on Tenki's default base
+// image. Mirrors assets/dockerfiles/Dockerfile.<agent>: install Node via
+// NodeSource only if it is missing, then `npm install -g` the CLI. `set -e` so an
+// early step failure aborts instead of being masked by a later success.
+function getAgentSetupCommand(agentType: AgentType): string {
+  const pkg = AGENT_CLI_PACKAGES[agentType];
+  return [
+    "set -e",
+    "if ! command -v node >/dev/null 2>&1; then curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && apt-get install -y nodejs; fi",
+    `npm install -g ${pkg}`,
+  ].join(" && ");
+}
+
+// Single-quote a value for safe interpolation into a bash command.
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function toMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// Pump a Tenki byte stream into a VibeKit string callback. Uses a single
+// streaming decoder so multi-byte UTF-8 sequences split across chunks are not
+// corrupted at the boundary.
+function pipeStream(
+  stream: ReadableStream<Uint8Array>,
+  onData: (data: string) => void
+): void {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  void (async () => {
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) onData(decoder.decode(value, { stream: true }));
+      }
+    } catch {
+      // Stream closed or sandbox torn down mid-read — nothing to do.
+    } finally {
+      reader.releaseLock();
+    }
+  })();
+}
+
+// Tenki implementation
+class TenkiSandboxInstance implements SandboxInstance {
+  constructor(
+    private session: Session,
+    public sandboxId: string
+  ) {}
+
+  get commands(): SandboxCommands {
+    return {
+      run: async (
+        command: string,
+        options?: SandboxCommandOptions
+      ): Promise<SandboxExecutionResult> => {
+        const { background, onStdout, onStderr, timeoutMs } = options || {};
+
+        try {
+          if (background) {
+            // Non-blocking: start the process, stream output, and return
+            // immediately so callers can e.g. getHost() a dev server.
+            const handle = this.session.run(["bash", "-lc", command]);
+            // Prevent an unhandled rejection if the detached process errors.
+            void Promise.resolve(handle).catch(() => {});
+            if (onStdout) pipeStream(handle.stdout, onStdout);
+            if (onStderr) pipeStream(handle.stderr, onStderr);
+            return {
+              exitCode: 0,
+              stdout: "Background command started successfully",
+              stderr: "",
+            };
+          }
+
+          // Foreground: run through a login shell so pipes, redirects and env
+          // expansion (and the agent CLIs on the login PATH) behave as expected.
+          // Persistent per-stream decoders avoid UTF-8 corruption at chunk
+          // boundaries; the final result is decoded from the full buffer.
+          const stdoutDecoder = new TextDecoder();
+          const stderrDecoder = new TextDecoder();
+          const result = await this.session.exec("bash", {
+            args: ["-lc", command],
+            timeoutMs,
+            onOutput: (output) => {
+              if (output.isStderr) {
+                onStderr?.(stderrDecoder.decode(output.data, { stream: true }));
+              } else {
+                onStdout?.(stdoutDecoder.decode(output.data, { stream: true }));
+              }
+            },
+          });
+
+          // Don't let a non-successful command (e.g. signaled/timed-out with a
+          // 0 exit code, such as SIGKILL) read as success.
+          const succeeded = isSuccess(result.status);
+          const stderr = stderrText(result);
+          return {
+            exitCode:
+              result.exitCode !== 0 ? result.exitCode : succeeded ? 0 : 1,
+            stdout: stdoutText(result),
+            stderr:
+              !succeeded && result.exitCode === 0 && !stderr
+                ? `Command did not complete successfully (status: ${result.status})`
+                : stderr,
+          };
+        } catch (error) {
+          const message = toMessage(error);
+          onStderr?.(message);
+          return { exitCode: 1, stdout: "", stderr: message };
+        }
+      },
+    };
+  }
+
+  async kill(): Promise<void> {
+    // Let teardown failures propagate — never report a failed terminate as
+    // success, so callers can retry.
+    await this.session.close();
+  }
+
+  async pause(): Promise<void> {
+    await this.session.pause();
+  }
+
+  async getHost(port: number): Promise<string> {
+    const exposed = await this.session.exposePort(port);
+    return exposed.previewUrl;
+  }
+}
+
+export class TenkiSandboxProvider implements SandboxProvider {
+  constructor(private config: TenkiConfig = {}) {}
+
+  private createClient(): TenkiSandbox {
+    return new TenkiSandbox({
+      authToken: this.config.apiKey,
+      baseUrl: this.config.baseUrl,
+    });
+  }
+
+  // Tenki scopes sandboxes to a workspace + project. Use the configured ids, or
+  // fall back to the account's first workspace/project via whoAmI().
+  private async resolveScope(
+    client: TenkiSandbox
+  ): Promise<{ workspaceId?: string; projectId: string }> {
+    if (this.config.projectId) {
+      return {
+        workspaceId: this.config.workspaceId,
+        projectId: this.config.projectId,
+      };
+    }
+    const identity = await client.whoAmI();
+    const workspace = identity.workspaces?.[0];
+    const project = workspace?.projects?.[0];
+    if (!project) {
+      throw new Error(
+        "Could not resolve a default Tenki project from the account; pass `projectId` (and `workspaceId`) in the provider config."
+      );
+    }
+    return {
+      workspaceId: this.config.workspaceId ?? workspace?.id,
+      projectId: project.id,
+    };
+  }
+
+  // Best-effort teardown used only for create-failure cleanup. It swallows the
+  // cleanup error on purpose so the original (actionable) setup error surfaces.
+  private async safeClose(session: Session): Promise<void> {
+    try {
+      await session.close();
+    } catch {
+      // Ignore — the setup failure is the one worth reporting.
+    }
+  }
+
+  async create(
+    envs?: Record<string, string>,
+    agentType?: AgentType,
+    workingDirectory?: string
+  ): Promise<SandboxInstance> {
+    const client = this.createClient();
+    const usesPrebuiltImage = Boolean(
+      this.config.image || this.config.snapshotId
+    );
+
+    let session: Session;
+    try {
+      const { workspaceId, projectId } = await this.resolveScope(client);
+      session = await client.create({
+        env: envs,
+        image: this.config.image,
+        snapshotId: this.config.snapshotId,
+        cpuCores: this.config.cpuCores,
+        memoryMb: this.config.memoryMb,
+        maxDurationMs: this.config.maxDurationMs,
+        idleTimeoutMinutes: this.config.idleTimeoutMinutes,
+        waitTimeoutMs: this.config.waitTimeoutMs,
+        sticky: this.config.sticky,
+        workspaceId,
+        projectId,
+      });
+    } catch (error) {
+      throw new Error(`Failed to create Tenki sandbox: ${toMessage(error)}`);
+    }
+
+    // The VM now exists. Any setup failure past this point must tear it down so
+    // we never leak a running sandbox (create is failure-atomic).
+    try {
+      const shouldInstall = this.config.installAgent ?? !usesPrebuiltImage;
+      if (shouldInstall && agentType) {
+        const setup = await session.exec("bash", {
+          args: ["-lc", getAgentSetupCommand(agentType)],
+        });
+        if (setup.exitCode !== 0 || !isSuccess(setup.status)) {
+          throw new Error(
+            `Failed to install the ${agentType} CLI in the Tenki sandbox: ${
+              stderrText(setup) || `status ${setup.status}`
+            }`
+          );
+        }
+      }
+
+      if (workingDirectory) {
+        const mkdir = await session.exec("bash", {
+          args: ["-lc", `mkdir -p ${shellSingleQuote(workingDirectory)}`],
+        });
+        if (mkdir.exitCode !== 0 || !isSuccess(mkdir.status)) {
+          throw new Error(
+            `Failed to create working directory ${workingDirectory}: ${
+              stderrText(mkdir) || `status ${mkdir.status}`
+            }`
+          );
+        }
+      }
+
+      return new TenkiSandboxInstance(session, session.id);
+    } catch (error) {
+      await this.safeClose(session);
+      throw new Error(
+        `Failed to set up Tenki sandbox (sandbox torn down): ${toMessage(error)}`
+      );
+    }
+  }
+
+  async resume(sandboxId: string): Promise<SandboxInstance> {
+    try {
+      const client = this.createClient();
+      const session = await client.get(sandboxId);
+      if (session.state === "PAUSED") {
+        await session.resume();
+      }
+      return new TenkiSandboxInstance(session, session.id);
+    } catch (error) {
+      throw new Error(`Failed to resume Tenki sandbox: ${toMessage(error)}`);
+    }
+  }
+}
+
+export function createTenkiProvider(
+  config: TenkiConfig = {}
+): TenkiSandboxProvider {
+  return new TenkiSandboxProvider(config);
+}

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -132,6 +132,36 @@ function toMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+// Tenki's documented resource ranges for create() (see @tenkicloud/sandbox).
+const CPU_CORES_RANGE = { min: 1, max: 16 };
+const MEMORY_MB_RANGE = { min: 128, max: 65536 };
+
+// Fail fast at construction on invalid resource config, rather than minutes
+// later mid-provisioning.
+function validateConfig(config: TenkiConfig): void {
+  const { cpuCores, memoryMb } = config;
+  if (
+    cpuCores !== undefined &&
+    (!Number.isInteger(cpuCores) ||
+      cpuCores < CPU_CORES_RANGE.min ||
+      cpuCores > CPU_CORES_RANGE.max)
+  ) {
+    throw new Error(
+      `Invalid Tenki config: cpuCores must be an integer in [${CPU_CORES_RANGE.min}, ${CPU_CORES_RANGE.max}], got ${cpuCores}.`
+    );
+  }
+  if (
+    memoryMb !== undefined &&
+    (!Number.isInteger(memoryMb) ||
+      memoryMb < MEMORY_MB_RANGE.min ||
+      memoryMb > MEMORY_MB_RANGE.max)
+  ) {
+    throw new Error(
+      `Invalid Tenki config: memoryMb must be an integer in [${MEMORY_MB_RANGE.min}, ${MEMORY_MB_RANGE.max}], got ${memoryMb}.`
+    );
+  }
+}
+
 // Pump a Tenki byte stream into a VibeKit string callback. Uses a single
 // streaming decoder so multi-byte UTF-8 sequences split across chunks are not
 // corrupted at the boundary.
@@ -244,7 +274,9 @@ class TenkiSandboxInstance implements SandboxInstance {
 }
 
 export class TenkiSandboxProvider implements SandboxProvider {
-  constructor(private config: TenkiConfig = {}) {}
+  constructor(private config: TenkiConfig = {}) {
+    validateConfig(config);
+  }
 
   private createClient(): TenkiSandbox {
     return new TenkiSandbox({
@@ -278,13 +310,15 @@ export class TenkiSandboxProvider implements SandboxProvider {
     };
   }
 
-  // Best-effort teardown used only for create-failure cleanup. It swallows the
-  // cleanup error on purpose so the original (actionable) setup error surfaces.
-  private async safeClose(session: Session): Promise<void> {
+  // Best-effort teardown used only for create-failure cleanup. Returns whether
+  // the sandbox was closed, so the caller can surface the id if teardown itself
+  // failed and the VM needs to be terminated manually.
+  private async safeClose(session: Session): Promise<boolean> {
     try {
       await session.close();
+      return true;
     } catch {
-      // Ignore — the setup failure is the one worth reporting.
+      return false;
     }
   }
 
@@ -350,9 +384,12 @@ export class TenkiSandboxProvider implements SandboxProvider {
 
       return new TenkiSandboxInstance(session, session.id);
     } catch (error) {
-      await this.safeClose(session);
+      const closed = await this.safeClose(session);
+      const detail = `Failed to set up Tenki sandbox: ${toMessage(error)}`;
       throw new Error(
-        `Failed to set up Tenki sandbox (sandbox torn down): ${toMessage(error)}`
+        closed
+          ? `${detail} (sandbox ${session.id} was torn down)`
+          : `${detail} (WARNING: automatic teardown of sandbox ${session.id} failed — terminate it manually)`
       );
     }
   }

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -370,8 +370,16 @@ export class TenkiSandboxProvider implements SandboxProvider {
       }
 
       if (workingDirectory) {
+        const dir = shellSingleQuote(workingDirectory);
+        // Tenki's default image runs as a non-root user, so a root-owned path
+        // (e.g. VibeKit's default "/vibe0") can't be created with a plain mkdir.
+        // Try as the current user first (works under $HOME), then fall back to
+        // sudo + chown so the directory is owned by — and writable for — us.
         const mkdir = await session.exec("bash", {
-          args: ["-lc", `mkdir -p ${shellSingleQuote(workingDirectory)}`],
+          args: [
+            "-lc",
+            `mkdir -p ${dir} 2>/dev/null || { sudo -n mkdir -p ${dir} && sudo -n chown "$(id -u):$(id -g)" ${dir}; }`,
+          ],
         });
         if (mkdir.exitCode !== 0 || !isSuccess(mkdir.status)) {
           throw new Error(

--- a/packages/tenki/src/index.ts
+++ b/packages/tenki/src/index.ts
@@ -57,10 +57,11 @@ export interface TenkiConfig {
   apiKey?: string;
   /** Override the Tenki API base URL (defaults to https://api.tenki.cloud). */
   baseUrl?: string;
-  /** Tenki workspace id. Auto-resolved from the account's first workspace when omitted. */
+  /**
+   * Explicit workspace scope — only needed for service-token callers. A normal
+   * Tenki workspace API key (`tk_…`) infers the workspace server-side.
+   */
   workspaceId?: string;
-  /** Tenki project id. Auto-resolved from the workspace's first project when omitted. */
-  projectId?: string;
   /**
    * Boot from a pre-built Tenki registry image (ref string or image object).
    * NOTE: this is a Tenki registry reference, NOT a Docker Hub image. When set,
@@ -285,31 +286,6 @@ export class TenkiSandboxProvider implements SandboxProvider {
     });
   }
 
-  // Tenki scopes sandboxes to a workspace + project. Use the configured ids, or
-  // fall back to the account's first workspace/project via whoAmI().
-  private async resolveScope(
-    client: TenkiSandbox
-  ): Promise<{ workspaceId?: string; projectId: string }> {
-    if (this.config.projectId) {
-      return {
-        workspaceId: this.config.workspaceId,
-        projectId: this.config.projectId,
-      };
-    }
-    const identity = await client.whoAmI();
-    const workspace = identity.workspaces?.[0];
-    const project = workspace?.projects?.[0];
-    if (!project) {
-      throw new Error(
-        "Could not resolve a default Tenki project from the account; pass `projectId` (and `workspaceId`) in the provider config."
-      );
-    }
-    return {
-      workspaceId: this.config.workspaceId ?? workspace?.id,
-      projectId: project.id,
-    };
-  }
-
   // Best-effort teardown used only for create-failure cleanup. Returns whether
   // the sandbox was closed, so the caller can surface the id if teardown itself
   // failed and the VM needs to be terminated manually.
@@ -334,7 +310,6 @@ export class TenkiSandboxProvider implements SandboxProvider {
 
     let session: Session;
     try {
-      const { workspaceId, projectId } = await this.resolveScope(client);
       session = await client.create({
         env: envs,
         image: this.config.image,
@@ -345,8 +320,8 @@ export class TenkiSandboxProvider implements SandboxProvider {
         idleTimeoutMinutes: this.config.idleTimeoutMinutes,
         waitTimeoutMs: this.config.waitTimeoutMs,
         sticky: this.config.sticky,
-        workspaceId,
-        projectId,
+        // Only needed for service-token callers; a workspace API key infers scope.
+        workspaceId: this.config.workspaceId,
       });
     } catch (error) {
       throw new Error(`Failed to create Tenki sandbox: ${toMessage(error)}`);

--- a/packages/tenki/tsconfig.json
+++ b/packages/tenki/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/test/helpers/test-utils.ts
+++ b/test/helpers/test-utils.ts
@@ -35,6 +35,7 @@ export const skipIfNoBeamKeys = () =>
   skipIfNoAPIKeys(["BEAM_API_KEY", "BEAM_WORKSPACE_ID", "OPENAI_API_KEY"]);
 export const skipIfNoBlaxelKeys = () =>
   skipIfNoAPIKeys(["ANTHROPIC_API_KEY", "BL_API_KEY", "BL_WORKSPACE"]);
+export const skipIfNoTenkiKeys = () => skipIfNoAPIKeys(["TENKI_AUTH_TOKEN"]);
 export const skipIfNoVibeKitKeys = () =>
   skipIfNoAPIKeys(["E2B_API_KEY", "ANTHROPIC_API_KEY", "GH_TOKEN"]);
 

--- a/test/tenki-integration.test.ts
+++ b/test/tenki-integration.test.ts
@@ -85,4 +85,26 @@ describe("Tenki Sandbox", () => {
       await sandbox.kill();
     }
   }, 240000);
+
+  it("creates a root-owned working directory on the non-root default image", async () => {
+    if (skipIntegrationTest() || skipIfNoTenkiKeys()) {
+      return skipTest();
+    }
+
+    // "/vibe0" (VibeKit's default working dir) is root-owned, and Tenki runs as
+    // a non-root user — so the provider must sudo-create + chown it. Verify the
+    // directory ends up writable by us.
+    const provider = createTenkiProvider({ installAgent: false });
+    const sandbox = await provider.create({}, undefined, "/vibe0");
+
+    try {
+      const check = await sandbox.commands.run(
+        "test -w /vibe0 && touch /vibe0/.probe && echo WRITABLE"
+      );
+      expect(check.exitCode).toBe(0);
+      expect(check.stdout).toContain("WRITABLE");
+    } finally {
+      await sandbox.kill();
+    }
+  }, 120000);
 });

--- a/test/tenki-integration.test.ts
+++ b/test/tenki-integration.test.ts
@@ -59,4 +59,30 @@ describe("Tenki Sandbox", () => {
       await sandbox.kill();
     }
   }, 120000);
+
+  it("installs and runs the requested agent CLI on the default image", async () => {
+    if (skipIntegrationTest() || skipIfNoTenkiKeys()) {
+      return skipTest();
+    }
+
+    // installAgent defaults to true, so this exercises the *real* create() path:
+    // boot the default base image, `npm i -g` the agent CLI, then invoke it.
+    const provider = createTenkiProvider({
+      apiKey: process.env.TENKI_AUTH_TOKEN,
+    });
+    const sandbox = await provider.create({}, "claude");
+
+    try {
+      // The CLI was installed and is on the PATH.
+      const which = await sandbox.commands.run("command -v claude");
+      expect(which.exitCode).toBe(0);
+      expect(which.stdout).toContain("claude");
+
+      // ...and it actually runs.
+      const version = await sandbox.commands.run("claude --version");
+      expect(version.exitCode).toBe(0);
+    } finally {
+      await sandbox.kill();
+    }
+  }, 240000);
 });

--- a/test/tenki-integration.test.ts
+++ b/test/tenki-integration.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { createTenkiProvider } from "../packages/tenki/dist/index.js";
+import {
+  skipIfNoTenkiKeys,
+  skipIntegrationTest,
+  skipTest,
+} from "./helpers/test-utils.js";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+describe("Tenki Sandbox", () => {
+  it("runs commands, streams output, exposes a port, and tears down", async () => {
+    if (skipIntegrationTest() || skipIfNoTenkiKeys()) {
+      return skipTest();
+    }
+
+    // `installAgent: false` keeps this a fast, self-contained test of the
+    // provider contract against a live sandbox — no agent CLI install needed.
+    const provider = createTenkiProvider({
+      apiKey: process.env.TENKI_AUTH_TOKEN,
+      installAgent: false,
+    });
+
+    const sandbox = await provider.create();
+
+    try {
+      expect(sandbox.sandboxId).toBeTruthy();
+
+      // Success: exit code 0 and stdout captured.
+      const ok = await sandbox.commands.run("echo hello-tenki");
+      expect(ok.exitCode).toBe(0);
+      expect(ok.stdout).toContain("hello-tenki");
+
+      // Failure: non-zero exit code propagates.
+      const failed = await sandbox.commands.run("exit 3");
+      expect(failed.exitCode).toBe(3);
+
+      // Shell semantics work (pipe + &&).
+      const piped = await sandbox.commands.run(
+        "printf 'a\\nb\\nc\\n' | grep -c ."
+      );
+      expect(piped.exitCode).toBe(0);
+      expect(piped.stdout.trim()).toBe("3");
+
+      // Streaming callback receives stdout.
+      let streamed = "";
+      await sandbox.commands.run("echo streamed-output", {
+        onStdout: (data) => {
+          streamed += data;
+        },
+      });
+      expect(streamed).toContain("streamed-output");
+
+      // Exposing a port returns a preview URL.
+      const host = await sandbox.getHost(3000);
+      expect(host).toMatch(/^https?:\/\//);
+    } finally {
+      await sandbox.kill();
+    }
+  }, 120000);
+});

--- a/test/tenki.test.ts
+++ b/test/tenki.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Module-level hooks the mock delegates to, so each test can shape behavior.
+const hooks = {
+  whoAmI: vi.fn(),
+  create: vi.fn(),
+};
+
+vi.mock("@tenkicloud/sandbox", () => {
+  class TenkiSandbox {
+    constructor(_options?: unknown) {}
+    whoAmI() {
+      return hooks.whoAmI();
+    }
+    create(options: unknown) {
+      return hooks.create(options);
+    }
+    get() {
+      return hooks.create({});
+    }
+  }
+  return {
+    TenkiSandbox,
+    isSuccess: (status: string) => status === "SUCCEEDED",
+    stdoutText: () => "",
+    stderrText: () => "",
+  };
+});
+
+// Import from dist to exercise the built package (as the other tests do).
+import { createTenkiProvider } from "../packages/tenki/dist/index.js";
+
+const identity = {
+  ownerType: "user",
+  ownerId: "u1",
+  workspaces: [{ id: "ws9", name: "ws", projects: [{ id: "proj9", name: "p" }] }],
+};
+
+describe("Tenki provider — lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hooks.whoAmI.mockResolvedValue(identity);
+  });
+
+  it("tears down the sandbox when setup fails after create (no leak)", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    hooks.create.mockResolvedValue({
+      id: "sb1",
+      state: "RUNNING",
+      exec: vi.fn().mockRejectedValue(new Error("install blew up")),
+      close,
+    });
+
+    const provider = createTenkiProvider({ apiKey: "tk_x", installAgent: true });
+
+    await expect(provider.create({}, "claude")).rejects.toThrow(/torn down/i);
+    // The created VM must be closed rather than leaked.
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates teardown failures from kill() instead of reporting success", async () => {
+    const close = vi.fn().mockRejectedValue(new Error("terminate failed"));
+    hooks.create.mockResolvedValue({
+      id: "sb1",
+      state: "RUNNING",
+      exec: vi.fn(),
+      close,
+    });
+
+    const provider = createTenkiProvider({ apiKey: "tk_x", installAgent: false });
+    const sandbox = await provider.create();
+
+    await expect(sandbox.kill()).rejects.toThrow(/terminate failed/);
+  });
+
+  it("auto-resolves workspace/project from whoAmI when not configured", async () => {
+    hooks.create.mockResolvedValue({
+      id: "sb1",
+      state: "RUNNING",
+      exec: vi.fn(),
+      close: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const provider = createTenkiProvider({ apiKey: "tk_x", installAgent: false });
+    await provider.create();
+
+    expect(hooks.create).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: "ws9", projectId: "proj9" })
+    );
+  });
+});

--- a/test/tenki.test.ts
+++ b/test/tenki.test.ts
@@ -36,6 +36,22 @@ const identity = {
   workspaces: [{ id: "ws9", name: "ws", projects: [{ id: "proj9", name: "p" }] }],
 };
 
+describe("Tenki provider — config validation", () => {
+  it("rejects out-of-range cpuCores at construction", () => {
+    expect(() => createTenkiProvider({ cpuCores: 999 })).toThrow(/cpuCores/);
+  });
+
+  it("rejects out-of-range memoryMb at construction", () => {
+    expect(() => createTenkiProvider({ memoryMb: 1 })).toThrow(/memoryMb/);
+  });
+
+  it("accepts valid resource config", () => {
+    expect(() =>
+      createTenkiProvider({ cpuCores: 2, memoryMb: 4096 })
+    ).not.toThrow();
+  });
+});
+
 describe("Tenki provider — lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -56,6 +72,22 @@ describe("Tenki provider — lifecycle", () => {
     await expect(provider.create({}, "claude")).rejects.toThrow(/torn down/i);
     // The created VM must be closed rather than leaked.
     expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the sandbox id when create-failure cleanup also fails", async () => {
+    hooks.create.mockResolvedValue({
+      id: "sb-leak-1",
+      state: "RUNNING",
+      exec: vi.fn().mockRejectedValue(new Error("install blew up")),
+      close: vi.fn().mockRejectedValue(new Error("terminate failed")),
+    });
+
+    const provider = createTenkiProvider({ apiKey: "tk_x", installAgent: true });
+    const err = await provider.create({}, "claude").catch((e) => e as Error);
+
+    // A leaked VM must be identifiable so it can be terminated by hand.
+    expect(String(err)).toContain("sb-leak-1");
+    expect(String(err)).toMatch(/manually/i);
   });
 
   it("propagates teardown failures from kill() instead of reporting success", async () => {

--- a/test/tenki.test.ts
+++ b/test/tenki.test.ts
@@ -1,17 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-// Module-level hooks the mock delegates to, so each test can shape behavior.
+// Module-level hook the mock delegates to, so each test can shape create().
 const hooks = {
-  whoAmI: vi.fn(),
   create: vi.fn(),
 };
 
 vi.mock("@tenkicloud/sandbox", () => {
   class TenkiSandbox {
     constructor(_options?: unknown) {}
-    whoAmI() {
-      return hooks.whoAmI();
-    }
     create(options: unknown) {
       return hooks.create(options);
     }
@@ -29,12 +25,6 @@ vi.mock("@tenkicloud/sandbox", () => {
 
 // Import from dist to exercise the built package (as the other tests do).
 import { createTenkiProvider } from "../packages/tenki/dist/index.js";
-
-const identity = {
-  ownerType: "user",
-  ownerId: "u1",
-  workspaces: [{ id: "ws9", name: "ws", projects: [{ id: "proj9", name: "p" }] }],
-};
 
 describe("Tenki provider — config validation", () => {
   it("rejects out-of-range cpuCores at construction", () => {
@@ -55,7 +45,6 @@ describe("Tenki provider — config validation", () => {
 describe("Tenki provider — lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    hooks.whoAmI.mockResolvedValue(identity);
   });
 
   it("tears down the sandbox when setup fails after create (no leak)", async () => {
@@ -105,7 +94,7 @@ describe("Tenki provider — lifecycle", () => {
     await expect(sandbox.kill()).rejects.toThrow(/terminate failed/);
   });
 
-  it("auto-resolves workspace/project from whoAmI when not configured", async () => {
+  it("passes a configured workspaceId through to create", async () => {
     hooks.create.mockResolvedValue({
       id: "sb1",
       state: "RUNNING",
@@ -113,11 +102,15 @@ describe("Tenki provider — lifecycle", () => {
       close: vi.fn().mockResolvedValue(undefined),
     });
 
-    const provider = createTenkiProvider({ apiKey: "tk_x", installAgent: false });
+    const provider = createTenkiProvider({
+      apiKey: "tk_x",
+      installAgent: false,
+      workspaceId: "ws9",
+    });
     await provider.create();
 
     expect(hooks.create).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceId: "ws9", projectId: "proj9" })
+      expect.objectContaining({ workspaceId: "ws9" })
     );
   });
 });


### PR DESCRIPTION
## What

Adds `@vibe-kit/tenki`, a sandbox provider that runs coding agents inside [Tenki](https://tenki.cloud) disposable microVMs, alongside the existing providers (e2b, daytona, blaxel, modal, …).

## Why

Tenki offers per-second microVMs with public preview URLs and pause/resume — a natural fit for VibeKit's "run an agent safely, watch it remotely" model.

## How it works

- Implements the standard `SandboxProvider` (`create`/`resume`) and `SandboxInstance` (`commands.run`, `kill`, `pause`, `getHost`) over `@tenkicloud/sandbox`, mirroring `packages/daytona` and `packages/blaxel`.
- On Tenki's default base image, installs the requested agent's CLI at `create()` time (`@anthropic-ai/claude-code`, `@openai/codex`, `@google/gemini-cli`, `opencode-ai`, `@vibe-kit/grok-cli`). Optionally boots a pre-built Tenki registry `image` / `snapshotId` instead.
- `getHost(port)` returns a public preview URL via `exposePort`.
- Tenki's default image runs as a non-root user, so the provider creates VibeKit's working directory (`/vibe0`) with a `sudo mkdir + chown` fallback to keep it writable.

## Reliability

- `create()` is failure-atomic: if agent-CLI install or workdir setup fails, the sandbox is torn down rather than leaked.
- Non-successful commands (e.g. signaled/timed-out with a 0 exit code) don't read as success; `kill()` surfaces teardown failures instead of swallowing them.
- Optional `maxDurationMs` / `idleTimeoutMinutes` lifetime backstops.

## Testing

- Offline unit tests (mocked): config validation, create-failure cleanup, teardown-failure propagation, `workspaceId` passthrough.
- Live integration tests (`test/tenki-integration.test.ts`, gated on `TENKI_AUTH_TOKEN`): create → run (piped shell + streaming) → `exposePort` → `kill`; agent-CLI install + invoke; root-owned working-dir creation. All green.
- Verified end-to-end through the VibeKit facade: `new VibeKit().withSandbox(createTenkiProvider())` → Tenki VM → Claude Code (via a Claude Max OAuth token) held a real conversation and ran a command inside the VM.

## Files

- `packages/tenki/*` — new provider package (`@tenkicloud/sandbox@^0.5.4`)
- `docs/supported-sandboxes/tenki.mdx` + `docs/docs.json` nav entry
- `test/tenki-integration.test.ts`, `test/tenki.test.ts`, `test/helpers/test-utils.ts`
